### PR TITLE
Support Go's long variable initialization

### DIFF
--- a/AuraLang/Compiler/Compiler.cs
+++ b/AuraLang/Compiler/Compiler.cs
@@ -189,9 +189,9 @@ public class AuraCompiler
                 // as the initializer of a `for` loop. Go only allows the short syntax (i.e. `x := 0`), whereas Aura allows both styles of variable
                 // declaration. Therefore, if the user has entered the full `let`-style syntax (i.e. `let x: int = 0`) inside the signature of a `for`
                 // loop, it must be compiled to the short syntax in the final Go file.
-                if (let.TypeAnnotation && _enclosingType.Peek() is TypedFor)
+                if (let.TypeAnnotation && _enclosingType.Peek() is not TypedFor)
                 {
-                    return $"var {let.Name.Value} {AuraTypeToGoType(let.Typ)} = {value}";
+                    return $"var {let.Name.Value} {AuraTypeToGoType(let.Initializer.Typ)} = {value}";
                 }
                 else
                 {


### PR DESCRIPTION
* Aura's full let-style variable initialization (i.e. `let i: int = 5`) will compile to Go's longer variable initialization syntax (i.e. `var i int = 5`)