### PR TITLE
Compile `yield` statement

### DIFF
--- a/AuraLang/Compiler/Compiler.cs
+++ b/AuraLang/Compiler/Compiler.cs
@@ -471,11 +471,13 @@ public class AuraCompiler
             switch (stmt)
             {
                 case TypedReturn r:
-                    var v = r.Value is not null ? Expression(r.Value) : string.Empty;
-                    body.Append($"\nreturn {v}");
+                    var returnVal = r.Value is not null ? Expression(r.Value) : string.Empty;
+                    body.Append($"\nreturn {returnVal}");
                     break;
                 case TypedYield y:
-                    
+                    var yieldVal = Expression(y.Value);
+                    body.Append($"\n{decl} = {yieldVal}");
+                    break;
                 default:
                     var s = Statement(stmt);
                     body.Append($"\n{s}");


### PR DESCRIPTION
* Since Go does not support the `yield` keyword, it gets compiled to an assignment statement
* This Aura snippet:
```
let i: int = if true {
    yield 0
} else {
    yield 1
}
```
would compile to this in Go:
```
var i int
if true {
    i = 0
} else {
    i = 1
}
```