### PR TITLE
Remove types from Parser

### DIFF
--- a/AuraLang.Test/Compiler/CompilerTest.cs
+++ b/AuraLang.Test/Compiler/CompilerTest.cs
@@ -99,9 +99,9 @@ public class CompilerTest
                                     new(
                                         "Println",
                                         new AnonymousFunction(
-                                            new List<ParamType>
+                                            new List<TypedParamType>
                                             {
-                                                new ParamType(new AuraString(), false)
+                                                new TypedParamType(new AuraString(), false, null)
                                             },
                                             new Nil()))
                                 }),
@@ -110,11 +110,12 @@ public class CompilerTest
                         new Function(
                             "println",
                             new AnonymousFunction(
-                                new List<ParamType>
+                                new List<TypedParamType>
                                 {
-                                    new ParamType(
+                                    new TypedParamType(
                                         new AuraString(),
-                                        false)
+                                        false,
+                                        null)
                                 },
                                 new Nil())),
                         1),
@@ -141,7 +142,7 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<ParamType>(),
+                                new List<TypedParamType>(),
                                 new Nil())),
                         1),
                     new List<TypedAuraExpression>(),
@@ -164,9 +165,9 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<ParamType>
+                                new List<TypedParamType>
                                 {
-                                    new ParamType(new Int(), false)
+                                    new TypedParamType(new Int(), false, null)
                                 },
                                 new Nil())),
                         1),
@@ -193,10 +194,10 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<ParamType>
+                                new List<TypedParamType>
                                 {
-                                    new(new Int(), false),
-                                    new(new AuraString(), false)
+                                    new(new Int(), false, null),
+                                    new(new AuraString(), false, null)
                                 },
                                 new Nil())),
                         1),
@@ -227,9 +228,9 @@ public class CompilerTest
                             {
                                 "name"
                             },
-                            new List<ParamType>
+                            new List<TypedParamType>
                             {
-                                new ParamType(new AuraString(), false)
+                                new TypedParamType(new AuraString(), false, null)
                             },
                             new List<Function>()),
                         1),
@@ -521,9 +522,9 @@ public class CompilerTest
                             {
                                 "name"
                             },
-                            new List<ParamType>
+                            new List<TypedParamType>
                             {
-                                new ParamType(new AuraString(), false)
+                                new TypedParamType(new AuraString(), false, null)
                             },
                             new List<Function>()),
                         1),
@@ -547,7 +548,7 @@ public class CompilerTest
                     new Class(
                         "Greeter",
                         new List<string>(),
-                        new List<ParamType>(),
+                        new List<TypedParamType>(),
                         new List<Function>()),
                     1),
                 1)
@@ -614,7 +615,7 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<ParamType>(),
+                                new List<TypedParamType>(),
                                 new Nil())),
                         1),
                     new List<TypedAuraExpression>(),
@@ -736,7 +737,7 @@ public class CompilerTest
         {
             new TypedNamedFunction(
                 new Tok(TokType.Identifier, "f", 1),
-                new List<Param>(),
+                new List<TypedParam>(),
                 new TypedBlock(new List<TypedAuraStatement>(), new Nil(), 1),
                 new Nil(),
                 Visibility.Private,
@@ -752,7 +753,7 @@ public class CompilerTest
         {
             new TypedExpressionStmt(
                 new TypedAnonymousFunction(
-                    new List<Param>(),
+                    new List<TypedParam>(),
                     new TypedBlock(new List<TypedAuraStatement>(), new Nil(), 1),
                     new Nil(),
                     1),
@@ -830,7 +831,7 @@ public class CompilerTest
         {
             new FullyTypedClass(
                 new Tok(TokType.Identifier, "Greeter", 1),
-                new List<Param>(),
+                new List<TypedParam>(),
                 new List<TypedNamedFunction>(),
                 Visibility.Public,
                 1)

--- a/AuraLang.Test/Parser/ParserTest.cs
+++ b/AuraLang.Test/Parser/ParserTest.cs
@@ -311,8 +311,8 @@ public class ParserTest
 						new UntypedIntLiteral(2, 3)
 					}
 				},
-                new String(),
-				new Int(),
+                new Tok(TokType.String, "string", 1),
+				new Tok(TokType.Int, "int", 1),
 				1),
 			1));
 	}
@@ -509,7 +509,7 @@ public class ParserTest
 		MakeAssertions(untypedAst, new UntypedFor(
 			new UntypedLet(
 				new Tok(TokType.Identifier, "i", 1),
-				new None(),
+				null,
 				false,
 				new UntypedIntLiteral(0, 1),
 				1),
@@ -571,9 +571,9 @@ public class ParserTest
 		});
 		MakeAssertions(untypedAst, new UntypedNamedFunction(
 			new Tok(TokType.Identifier, "f", 1),
-			new List<Param>(),
+			new List<UntypedParam>(),
 			new UntypedBlock(new List<UntypedAuraStatement>(), 1),
-			new Nil(),
+			null,
 			Visibility.Private,
 			1));
 	}
@@ -593,9 +593,9 @@ public class ParserTest
 		});
 		MakeAssertions(untypedAst, new UntypedExpressionStmt(
 				new UntypedAnonymousFunction(
-					new List<Param>(),
+					new List<UntypedParam>(),
 					new UntypedBlock(new List<UntypedAuraStatement>(), 1),
-					new Nil(),
+					null,
 					1),
 			1));
 	}
@@ -616,7 +616,7 @@ public class ParserTest
 		});
 		MakeAssertions(untypedAst, new UntypedLet(
 			new Tok(TokType.Identifier, "i", 1),
-			new Int(),
+			new Tok(TokType.Int, "int", 1),
 			false,
 			new UntypedIntLiteral(5, 1),
 			1));
@@ -635,7 +635,7 @@ public class ParserTest
 		});
 		MakeAssertions(untypedAst, new UntypedLet(
 			new Tok(TokType.Identifier, "i", 1),
-			new None(),
+			null,
 			false,
 			new UntypedIntLiteral(5, 1),
 			1));
@@ -685,7 +685,7 @@ public class ParserTest
 		});
 		MakeAssertions(untypedAst, new UntypedClass(
 			new Tok(TokType.Identifier, "c", 1),
-			new List<Param>(),
+			new List<UntypedParam>(),
 			new List<UntypedNamedFunction>(),
 			Visibility.Private,
 			1));

--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -104,7 +104,7 @@ public class TypeCheckerTest
                     {
                         new UntypedLet(
                             new Tok(TokType.Identifier, "i", 2),
-                            new Int(),
+                            new Tok(TokType.Int, "int", 1),
                             false,
                             new UntypedIntLiteral(5, 2),
                             2)
@@ -138,7 +138,7 @@ public class TypeCheckerTest
             new Function(
                 "f",
                 new AnonymousFunction(
-                    new List<ParamType>(),
+                    new List<TypedParamType>(),
                     new Nil())),
             1,
             "main"));
@@ -157,7 +157,7 @@ public class TypeCheckerTest
             new TypedCall(
                 new TypedVariable(
                     new Tok(TokType.Identifier, "f", 1),
-                    new Function("f", new AnonymousFunction(new List<ParamType>(), new Nil())),
+                    new Function("f", new AnonymousFunction(new List<TypedParamType>(), new Nil())),
                     1),
                 new List<TypedAuraExpression>(),
                 new Nil(),
@@ -177,9 +177,9 @@ public class TypeCheckerTest
                     {
                         "name"
                     },
-                    new List<ParamType>
+                    new List<TypedParamType>
                     {
-                        new ParamType(new AuraString(), false)
+                        new TypedParamType(new AuraString(), false, null)
                     },
                     new List<Function>()),
                 1,
@@ -206,9 +206,9 @@ public class TypeCheckerTest
                         {
                             "name"
                         },
-                        new List<ParamType>
+                        new List<TypedParamType>
                         {
-                            new ParamType(new AuraString(), false)
+                            new TypedParamType(new AuraString(), false, null)
                         },
                         new List<Function>()),
                     1),
@@ -411,8 +411,8 @@ public class TypeCheckerTest
                     {
                         { new UntypedStringLiteral("Hello", 1), new UntypedIntLiteral(1, 1) }
                     },
-                    new AuraString(),
-                    new Int(),
+                    new Tok(TokType.String, "string", 1),
+                    new Tok(TokType.Int, "int", 1),
                     1),
                 1)
         });
@@ -504,9 +504,9 @@ public class TypeCheckerTest
                     {
                         "name"
                     },
-                    new List<ParamType>
+                    new List<TypedParamType>
                     {
-                        new(new AuraString(), false)
+                        new(new AuraString(), false, null)
                     },
                     new List<Function>()),
                 1,
@@ -534,9 +534,9 @@ public class TypeCheckerTest
                         {
                             "name"
                         },
-                        new List<ParamType>
+                        new List<TypedParamType>
                         {
-                            new ParamType(new AuraString(), false)
+                            new TypedParamType(new AuraString(), false, null)
                         },
                         new List<Function>()),
                     1),
@@ -553,13 +553,13 @@ public class TypeCheckerTest
         _enclosingClassStore.Setup(ecs => ecs.Peek())
             .Returns(new PartiallyTypedClass(
                 new Tok(TokType.Identifier, "Greeter", 1),
-                new List<Param>(),
+                new List<UntypedParam>(),
                 new List<PartiallyTypedFunction>(),
                 Visibility.Public,
                 new Class(
                     "Greeter",
                     new List<string>(),
-                    new List<ParamType>(),
+                    new List<TypedParamType>(),
                     new List<Function>()),
                 1));
         
@@ -577,7 +577,7 @@ public class TypeCheckerTest
                 new Class(
                     "Greeter",
                     new List<string>(),
-                    new List<ParamType>(),
+                    new List<TypedParamType>(),
                     new List<Function>()),
                 1),
             1));
@@ -662,7 +662,7 @@ public class TypeCheckerTest
                 new Function(
                     "f",
                     new AnonymousFunction(
-                        new List<ParamType>(),
+                        new List<TypedParamType>(),
                         new Nil())),
                 1,
                 "main"));
@@ -685,7 +685,7 @@ public class TypeCheckerTest
                     new Function(
                         "f",
                         new AnonymousFunction(
-                            new List<ParamType>(),
+                            new List<TypedParamType>(),
                             new Nil())),
                     1),
                 new List<TypedAuraExpression>(),
@@ -711,7 +711,7 @@ public class TypeCheckerTest
             new UntypedFor(
                 new UntypedLet(
                     new Tok(TokType.Identifier, "i", 1),
-                    new None(),
+                    null,
                     false,
                     new UntypedIntLiteral(0, 1),
                     1),
@@ -784,15 +784,15 @@ public class TypeCheckerTest
         {
             new UntypedNamedFunction(
                 new Tok(TokType.Identifier, "f", 1),
-                new List<Param>(),
+                new List<UntypedParam>(),
                 new UntypedBlock(new List<UntypedAuraStatement>(), 1),
-                new Nil(),
+                null,
                 Visibility.Public,
                 1)
         });
         MakeAssertions(typedAst, new TypedNamedFunction(
             new Tok(TokType.Identifier, "f", 1),
-            new List<Param>(),
+            new List<TypedParam>(),
             new TypedBlock(new List<TypedAuraStatement>(), new Nil(), 1),
             new Nil(),
             Visibility.Public,
@@ -806,15 +806,15 @@ public class TypeCheckerTest
         {
             new UntypedExpressionStmt(
                 new UntypedAnonymousFunction(
-                    new List<Param>(),
+                    new List<UntypedParam>(),
                     new UntypedBlock(new List<UntypedAuraStatement>(), 1),
-                    new Nil(),
+                    null,
                     1),
                 1)
         });
         MakeAssertions(typedAst, new TypedExpressionStmt(
             new TypedAnonymousFunction(
-                new List<Param>(),
+                new List<TypedParam>(),
                 new TypedBlock(
                     new List<TypedAuraStatement>(),
                     new Nil(),
@@ -831,7 +831,7 @@ public class TypeCheckerTest
         {
             new UntypedLet(
                 new Tok(TokType.Identifier, "i", 1),
-                new Int(),
+                new Tok(TokType.Int, "int", 1),
                 false,
                 new UntypedIntLiteral(1, 1),
                 1)
@@ -851,7 +851,7 @@ public class TypeCheckerTest
         {
             new UntypedLet(
                 new Tok(TokType.Identifier, "i", 1),
-                new None(),
+                null,
                 false,
                 new UntypedIntLiteral(1, 1),
                 1)
@@ -899,14 +899,14 @@ public class TypeCheckerTest
         {
             new UntypedClass(
                 new Tok(TokType.Identifier, "Greeter", 1),
-                new List<Param>(),
+                new List<UntypedParam>(),
                 new List<UntypedNamedFunction>(),
                 Visibility.Private,
                 1)
         });
         MakeAssertions(typedAst, new FullyTypedClass(
             new Tok(TokType.Identifier, "Greeter", 1),
-            new List<Param>(),
+            new List<TypedParam>(),
             new List<TypedNamedFunction>(),
             Visibility.Private,
             1));

--- a/AuraLang/AST/IFunction.cs
+++ b/AuraLang/AST/IFunction.cs
@@ -2,9 +2,14 @@
 
 namespace AuraLang.AST;
 
-public interface IFunction
+public interface IUntypedFunction
 {
-	public List<Param> GetParams();
-	public List<ParamType> GetParamTypes();
+	public List<UntypedParam> GetParams();
+	public List<UntypedParamType> GetParamTypes();
 }
 
+public interface ITypedFunction
+{
+	public List<TypedParam> GetParams();
+	public List<TypedParamType> GetParamTypes();
+}

--- a/AuraLang/AST/IFunction.cs
+++ b/AuraLang/AST/IFunction.cs
@@ -4,6 +4,7 @@ namespace AuraLang.AST;
 
 public interface IFunction
 {
+	public List<Param> GetParams();
 	public List<ParamType> GetParamTypes();
 }
 

--- a/AuraLang/AST/PartialAst.cs
+++ b/AuraLang/AST/PartialAst.cs
@@ -11,12 +11,10 @@ namespace AuraLang.AST;
 /// <param name="Params">The partially type function's parameters</param>
 /// <param name="Body">The partially typed function's body</param>
 /// <param name="ReturnType">The partially typed function's return type</param>
-public record PartiallyTypedFunction(Tok Name, List<Param> Params, UntypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : TypedAuraStatement(ReturnType, Line), IFunction
+public record PartiallyTypedFunction(Tok Name, List<UntypedParam> Params, UntypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : TypedAuraStatement(ReturnType, Line), IUntypedFunction
 {
-    public PartiallyTypedFunction(UntypedNamedFunction f) : this(f.Name, f.Params, f.Body, f.ReturnType, f.Public, f.Line) { }
-
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
-    public List<Param> GetParams() => Params;
+    public List<UntypedParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<UntypedParam> GetParams() => Params;
 }
 
 /// <summary>
@@ -26,8 +24,8 @@ public record PartiallyTypedFunction(Tok Name, List<Param> Params, UntypedBlock 
 /// <param name="Params">The partially typed class's parameters</param>
 /// <param name="Methods">The partially typed class's methods</param>
 /// <param name="Public">Indicates if the partially typed class is public or not</param>
-public record PartiallyTypedClass(Tok Name, List<Param> Params, List<PartiallyTypedFunction> Methods, Visibility Public, AuraType Typ, int Line) : TypedAuraStatement(Typ, Line), IFunction
+public record PartiallyTypedClass(Tok Name, List<UntypedParam> Params, List<PartiallyTypedFunction> Methods, Visibility Public, AuraType Typ, int Line) : TypedAuraStatement(Typ, Line), IUntypedFunction
 {
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
-    public List<Param> GetParams() => Params;
+    public List<UntypedParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<UntypedParam> GetParams() => Params;
 }

--- a/AuraLang/AST/PartialAst.cs
+++ b/AuraLang/AST/PartialAst.cs
@@ -16,6 +16,7 @@ public record PartiallyTypedFunction(Tok Name, List<Param> Params, UntypedBlock 
     public PartiallyTypedFunction(UntypedNamedFunction f) : this(f.Name, f.Params, f.Body, f.ReturnType, f.Public, f.Line) { }
 
     public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<Param> GetParams() => Params;
 }
 
 /// <summary>
@@ -28,4 +29,5 @@ public record PartiallyTypedFunction(Tok Name, List<Param> Params, UntypedBlock 
 public record PartiallyTypedClass(Tok Name, List<Param> Params, List<PartiallyTypedFunction> Methods, Visibility Public, AuraType Typ, int Line) : TypedAuraStatement(Typ, Line), IFunction
 {
     public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<Param> GetParams() => Params;
 }

--- a/AuraLang/AST/TypedAst.cs
+++ b/AuraLang/AST/TypedAst.cs
@@ -181,10 +181,10 @@ public record TypedForEach(Tok EachName, TypedAuraExpression Iterable, List<Type
 /// <param name="Params">The function's parameters</param>
 /// <param name="Body">The function's body</param>
 /// <param name="ReturnType">The function's return type</param>
-public record TypedNamedFunction(Tok Name, List<Param> Params, TypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : TypedAuraStatement(new None(), Line), IFunction
+public record TypedNamedFunction(Tok Name, List<TypedParam> Params, TypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : TypedAuraStatement(new None(), Line), ITypedFunction
 {
-    public List<Param> GetParams() => Params;
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<TypedParam> GetParams() => Params;
+    public List<TypedParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
 }
 
 /// <summary>
@@ -193,10 +193,10 @@ public record TypedNamedFunction(Tok Name, List<Param> Params, TypedBlock Body, 
 /// <param name="Params">The anonymous function's parameters</param>
 /// <param name="Body">The anonymous function's body</param>
 /// <param name="ReturnType">The anonymous function's return type</param>
-public record TypedAnonymousFunction(List<Param> Params, TypedBlock Body, AuraType ReturnType, int Line) : TypedAuraExpression(new None(), Line), IFunction
+public record TypedAnonymousFunction(List<TypedParam> Params, TypedBlock Body, AuraType ReturnType, int Line) : TypedAuraExpression(new None(), Line), ITypedFunction
 {
-    public List<Param> GetParams() => Params;
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<TypedParam> GetParams() => Params;
+    public List<TypedParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
 }
 
 /// <summary>
@@ -227,10 +227,10 @@ public record TypedReturn(TypedAuraExpression? Value, int Line) : TypedAuraState
 /// <param name="Params">The class's parameters</param>
 /// <param name="Methods">The class's methods</param>
 /// <param name="Public">Indicates whether the class is declared as public</param>
-public record FullyTypedClass(Tok Name, List<Param> Params, List<TypedNamedFunction> Methods, Visibility Public, int Line) : TypedAuraStatement(new None(), Line), IFunction
+public record FullyTypedClass(Tok Name, List<TypedParam> Params, List<TypedNamedFunction> Methods, Visibility Public, int Line) : TypedAuraStatement(new None(), Line), ITypedFunction
 {
-    public List<Param> GetParams() => Params;
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<TypedParam> GetParams() => Params;
+    public List<TypedParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
     
 }
 

--- a/AuraLang/AST/TypedAst.cs
+++ b/AuraLang/AST/TypedAst.cs
@@ -183,6 +183,7 @@ public record TypedForEach(Tok EachName, TypedAuraExpression Iterable, List<Type
 /// <param name="ReturnType">The function's return type</param>
 public record TypedNamedFunction(Tok Name, List<Param> Params, TypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : TypedAuraStatement(new None(), Line), IFunction
 {
+    public List<Param> GetParams() => Params;
     public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
 }
 
@@ -194,6 +195,7 @@ public record TypedNamedFunction(Tok Name, List<Param> Params, TypedBlock Body, 
 /// <param name="ReturnType">The anonymous function's return type</param>
 public record TypedAnonymousFunction(List<Param> Params, TypedBlock Body, AuraType ReturnType, int Line) : TypedAuraExpression(new None(), Line), IFunction
 {
+    public List<Param> GetParams() => Params;
     public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
 }
 
@@ -227,7 +229,9 @@ public record TypedReturn(TypedAuraExpression? Value, int Line) : TypedAuraState
 /// <param name="Public">Indicates whether the class is declared as public</param>
 public record FullyTypedClass(Tok Name, List<Param> Params, List<TypedNamedFunction> Methods, Visibility Public, int Line) : TypedAuraStatement(new None(), Line), IFunction
 {
+    public List<Param> GetParams() => Params;
     public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    
 }
 
 /// <summary>

--- a/AuraLang/AST/UntypedAst.cs
+++ b/AuraLang/AST/UntypedAst.cs
@@ -189,7 +189,7 @@ public record UntypedListLiteral<T>(List<T> L, int Line) : UntypedAuraExpression
 /// <typeparam name="K">The type of the map's keys</typeparam>
 /// <typeparam name="V">The type of the map's values</typeparam>
 /// <param name="M">The map value</param>
-public record UntypedMapLiteral(Dictionary<UntypedAuraExpression, UntypedAuraExpression> M, AuraType KeyType, AuraType ValueType, int Line) : UntypedAuraExpression(Line), IUntypedLiteral<Dictionary<UntypedAuraExpression, UntypedAuraExpression>>
+public record UntypedMapLiteral(Dictionary<UntypedAuraExpression, UntypedAuraExpression> M, Tok KeyType, Tok ValueType, int Line) : UntypedAuraExpression(Line), IUntypedLiteral<Dictionary<UntypedAuraExpression, UntypedAuraExpression>>
 {
     public Dictionary<UntypedAuraExpression, UntypedAuraExpression> GetValue() => M;
 }
@@ -317,12 +317,13 @@ public record UntypedForEach(Tok EachName, UntypedAuraExpression Iterable, List<
 /// <param name="Name">The function's name</param>
 /// <param name="Params">The function's parameters</param>
 /// <param name="Body">The function's body</param>
-/// <param name="ReturnType">The function's return type</param>
+/// <param name="ReturnType">The function's return type. This struct stores it as a token instead of a type because it hasn't
+/// been type checked yet.</param>
 /// <param name="Public">Indicates if the function is public or private</param>
-public record UntypedNamedFunction(Tok Name, List<Param> Params, UntypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : UntypedAuraStatement(Line), IFunction
+public record UntypedNamedFunction(Tok Name, List<UntypedParam> Params, UntypedBlock Body, Tok? ReturnType, Visibility Public, int Line) : UntypedAuraStatement(Line), IUntypedFunction
 {
-    public List<Param> GetParams() => Params;
-    public List<ParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
+    public List<UntypedParam> GetParams() => Params;
+    public List<UntypedParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
 }
 
 /// <summary>
@@ -331,11 +332,12 @@ public record UntypedNamedFunction(Tok Name, List<Param> Params, UntypedBlock Bo
 /// </summary>
 /// <param name="Params">The function's parameters</param>
 /// <param name="Body">The function's body</param>
-/// <param name="ReturnType">The function's return type</param>
-public record UntypedAnonymousFunction(List<Param> Params, UntypedBlock Body, AuraType ReturnType, int Line) : UntypedAuraExpression(Line), IFunction
+/// <param name="ReturnType">The function's return type. This struct stores it as a token instead of a type because it hasn't
+/// /// been type checked yet.</param>
+public record UntypedAnonymousFunction(List<UntypedParam> Params, UntypedBlock Body, Tok? ReturnType, int Line) : UntypedAuraExpression(Line), IUntypedFunction
 {
-    public List<Param> GetParams() => Params;
-    public List<ParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
+    public List<UntypedParam> GetParams() => Params;
+    public List<UntypedParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
 }
 
 /// <summary>
@@ -350,7 +352,7 @@ public record UntypedAnonymousFunction(List<Param> Params, UntypedBlock Body, Au
 /// be <see cref="Unknown"/></param>
 /// <param name="Mutable">Indicates if the variable is mutable or not</param>
 /// <param name="Initializer">The initializer expression whose result will be assigned to the new variable. This expression may be omitted.</param>
-public record UntypedLet(Tok Name, AuraType NameTyp, bool Mutable, UntypedAuraExpression? Initializer, int Line) : UntypedAuraStatement(Line);
+public record UntypedLet(Tok Name, Tok? NameTyp, bool Mutable, UntypedAuraExpression? Initializer, int Line) : UntypedAuraStatement(Line);
 
 /// <summary>
 /// Represents the current source file's module declaration. It should appear at the top of the file and have
@@ -375,10 +377,10 @@ public record UntypedReturn(UntypedAuraExpression? Value, int Line) : UntypedAur
 /// <param name="Params">The class's parameters</param>
 /// <param name="Methods">The class's methods</param>
 /// <param name="Public">Indicates if the class is public or not</param>
-public record UntypedClass(Tok Name, List<Param> Params, List<UntypedNamedFunction> Methods, Visibility Public, int Line) : UntypedAuraStatement(Line), IFunction
+public record UntypedClass(Tok Name, List<UntypedParam> Params, List<UntypedNamedFunction> Methods, Visibility Public, int Line) : UntypedAuraStatement(Line), IUntypedFunction
 {
-    public List<Param> GetParams() => Params;
-    public List<ParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
+    public List<UntypedParam> GetParams() => Params;
+    public List<UntypedParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
 }
 
 /// <summary>

--- a/AuraLang/AST/UntypedAst.cs
+++ b/AuraLang/AST/UntypedAst.cs
@@ -321,7 +321,8 @@ public record UntypedForEach(Tok EachName, UntypedAuraExpression Iterable, List<
 /// <param name="Public">Indicates if the function is public or private</param>
 public record UntypedNamedFunction(Tok Name, List<Param> Params, UntypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : UntypedAuraStatement(Line), IFunction
 {
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<Param> GetParams() => Params;
+    public List<ParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
 }
 
 /// <summary>
@@ -333,7 +334,8 @@ public record UntypedNamedFunction(Tok Name, List<Param> Params, UntypedBlock Bo
 /// <param name="ReturnType">The function's return type</param>
 public record UntypedAnonymousFunction(List<Param> Params, UntypedBlock Body, AuraType ReturnType, int Line) : UntypedAuraExpression(Line), IFunction
 {
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<Param> GetParams() => Params;
+    public List<ParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
 }
 
 /// <summary>
@@ -375,7 +377,8 @@ public record UntypedReturn(UntypedAuraExpression? Value, int Line) : UntypedAur
 /// <param name="Public">Indicates if the class is public or not</param>
 public record UntypedClass(Tok Name, List<Param> Params, List<UntypedNamedFunction> Methods, Visibility Public, int Line) : UntypedAuraStatement(Line), IFunction
 {
-    public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
+    public List<Param> GetParams() => Params;
+    public List<ParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
 }
 
 /// <summary>

--- a/AuraLang/Compiler/Compiler.cs
+++ b/AuraLang/Compiler/Compiler.cs
@@ -448,7 +448,7 @@ public class AuraCompiler
             : string.Empty;
     }
 
-    private string CompileParams(List<Param> params_, string sep)
+    private string CompileParams(List<TypedParam> params_, string sep)
     {
         return params_
             .Select(p => $"{p.Name.Value} {AuraTypeToGoType(p.ParamType.Typ)}")

--- a/AuraLang/Shared/Parameter.cs
+++ b/AuraLang/Shared/Parameter.cs
@@ -1,8 +1,13 @@
-﻿using AuraLang.Token;
+﻿using AuraLang.AST;
+using AuraLang.Token;
 using AuraLang.Types;
 
 namespace AuraLang.Shared;
 
-public record struct Param(Tok Name, ParamType ParamType);
+public record struct UntypedParam(Tok Name, UntypedParamType ParamType);
 
-public record struct ParamType(AuraType Typ, bool Variadic);
+public record struct UntypedParamType(Tok Typ, bool Variadic, UntypedAuraExpression? DefaultValue);
+
+public record struct TypedParam(Tok Name, TypedParamType ParamType);
+
+public record struct TypedParamType(AuraType Typ, bool Variadic, TypedAuraExpression? DefaultValue);

--- a/AuraLang/Stdlib/Stdlib.cs
+++ b/AuraLang/Stdlib/Stdlib.cs
@@ -15,19 +15,19 @@ public class AuraStdlib
             new(
                 "println",
                 new AnonymousFunction(
-                    new List<ParamType>
+                    new List<TypedParamType>
                     {
-                        new(new AuraString(), false)
+                        new(new AuraString(), false, null)
                     },
                     new Nil())
                 ),
             new(
                 "printf",
                 new AnonymousFunction(
-                    new List<ParamType>
+                    new List<TypedParamType>
                     {
-                        new(new AuraString(), false),
-                        new(new Any(), true)
+                        new(new AuraString(), false, null),
+                        new(new Any(), true, null)
                     },
                     new Nil())
                 )

--- a/AuraLang/Stdlib/Stdlib.cs
+++ b/AuraLang/Stdlib/Stdlib.cs
@@ -1,5 +1,6 @@
 using AuraLang.Compiler;
 using AuraLang.Shared;
+using AuraLang.Token;
 using AuraLang.Types;
 using AuraString = AuraLang.Types.String;
 

--- a/AuraLang/Types/AuraType.cs
+++ b/AuraLang/Types/AuraType.cs
@@ -150,7 +150,7 @@ public class Function : AuraType, ICallable
     }
 
     public override string ToString() => "function";
-    public List<ParamType> GetParamTypes() => F.ParamTypes;
+    public List<TypedParamType> GetParamTypes() => F.ParamTypes;
     public AuraType GetReturnType() => F.ReturnType;
 }
 
@@ -160,10 +160,10 @@ public class Function : AuraType, ICallable
 /// </summary>
 public class AnonymousFunction : AuraType, ICallable
 {
-    public List<ParamType> ParamTypes { get; }
+    public List<TypedParamType> ParamTypes { get; }
     public AuraType ReturnType { get; }
 
-    public AnonymousFunction(List<ParamType> paramTypes, AuraType returnType)
+    public AnonymousFunction(List<TypedParamType> paramTypes, AuraType returnType)
     {
         ParamTypes = paramTypes;
         ReturnType = returnType;
@@ -182,7 +182,7 @@ public class AnonymousFunction : AuraType, ICallable
         return $"fn({pt}) -> {ReturnType}";
     }
 
-    public List<ParamType> GetParamTypes() => ParamTypes;
+    public List<TypedParamType> GetParamTypes() => ParamTypes;
     public AuraType GetReturnType() => ReturnType;
 }
 
@@ -194,10 +194,10 @@ public class Class : AuraType, IGettable
 {
     public string Name { get; init; }
     public List<string> ParamNames { get; init; }
-    public List<ParamType> ParamTypes { get; init; }
+    public List<TypedParamType> ParamTypes { get; init; }
     public List<Function> Methods { get; init; }
 
-    public Class(string name, List<string> paramNames, List<ParamType> paramTypes, List<Function> methods)
+    public Class(string name, List<string> paramNames, List<TypedParamType> paramTypes, List<Function> methods)
     {
         Name = name;
         ParamNames = paramNames;

--- a/AuraLang/Types/AuraType.cs
+++ b/AuraLang/Types/AuraType.cs
@@ -78,7 +78,7 @@ public class Float : AuraType
 /// </summary>
 public class String : AuraType, IIterable, IIndexable, IRangeIndexable
 {
-    override public bool IsSameType(AuraType other)
+    public override bool IsSameType(AuraType other)
     {
         return other is String;
     }
@@ -111,7 +111,7 @@ public class List : AuraType, IIterable, IIndexable, IRangeIndexable
     /// <summary>
     /// The type of the elements in the list
     /// </summary>
-    public AuraType Kind { get; init; }
+    private AuraType Kind { get; init; }
 
     public List(AuraType kind)
     {
@@ -136,7 +136,7 @@ public class List : AuraType, IIterable, IIndexable, IRangeIndexable
 public class Function : AuraType, ICallable
 {
     public string Name { get; init; }
-    public AnonymousFunction F { get; init; }
+    private AnonymousFunction F { get; init; }
 
     public Function(string name, AnonymousFunction f)
     {
@@ -150,7 +150,7 @@ public class Function : AuraType, ICallable
     }
 
     public override string ToString() => "function";
-    public List<ParamType> GetParamTypes() => F.Params;
+    public List<ParamType> GetParamTypes() => F.ParamTypes;
     public AuraType GetReturnType() => F.ReturnType;
 }
 
@@ -160,12 +160,12 @@ public class Function : AuraType, ICallable
 /// </summary>
 public class AnonymousFunction : AuraType, ICallable
 {
-    public List<ParamType> Params { get; init; }
-    public AuraType ReturnType { get; init; }
+    public List<ParamType> ParamTypes { get; }
+    public AuraType ReturnType { get; }
 
-    public AnonymousFunction(List<ParamType> params_, AuraType returnType)
+    public AnonymousFunction(List<ParamType> paramTypes, AuraType returnType)
     {
-        Params = params_;
+        ParamTypes = paramTypes;
         ReturnType = returnType;
     }
 
@@ -176,13 +176,13 @@ public class AnonymousFunction : AuraType, ICallable
 
     public override string ToString()
     {
-        var params_ = Params
+        var pt = ParamTypes
             .Select(p => p.ToString())
             .Aggregate("", (prev, curr) => $"{prev}, {curr}");
-        return $"fn({params_}) -> {ReturnType}";
+        return $"fn({pt}) -> {ReturnType}";
     }
 
-    public List<ParamType> GetParamTypes() => Params;
+    public List<ParamType> GetParamTypes() => ParamTypes;
     public AuraType GetReturnType() => ReturnType;
 }
 

--- a/AuraLang/Types/ICallable.cs
+++ b/AuraLang/Types/ICallable.cs
@@ -4,7 +4,7 @@ namespace AuraLang.Types;
 
 public interface ICallable
 {
-    List<ParamType> GetParamTypes();
+    List<TypedParamType> GetParamTypes();
     AuraType GetReturnType();
 }
 


### PR DESCRIPTION
* The Parser shouldn't need to deal with types at all, so in places where the Parse was adding types, it now deals with tokens instead
* Types should be handled as much as possible by the Type Checker, so this PR makes the repo closer aligned to that idea