### PR TITLE
Support argument tagging

### DIFF
--- a/AuraLang.Test/Compiler/CompilerTest.cs
+++ b/AuraLang.Test/Compiler/CompilerTest.cs
@@ -99,9 +99,11 @@ public class CompilerTest
                                     new(
                                         "Println",
                                         new AnonymousFunction(
-                                            new List<TypedParamType>
+                                            new List<TypedParam>
                                             {
-                                                new TypedParamType(new AuraString(), false, null)
+                                                new(
+                                                    new Tok(TokType.Identifier, "s", 1),
+                                                    new TypedParamType(new AuraString(), false, null))
                                             },
                                             new Nil()))
                                 }),
@@ -110,12 +112,14 @@ public class CompilerTest
                         new Function(
                             "println",
                             new AnonymousFunction(
-                                new List<TypedParamType>
+                                new List<TypedParam>
                                 {
-                                    new TypedParamType(
-                                        new AuraString(),
-                                        false,
-                                        null)
+                                    new TypedParam(
+                                        new Tok(TokType.Identifier, "s", 1),
+                                        new TypedParamType(
+                                            new AuraString(),
+                                            false,
+                                            null))
                                 },
                                 new Nil())),
                         1),
@@ -142,7 +146,7 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<TypedParamType>(),
+                                new List<TypedParam>(),
                                 new Nil())),
                         1),
                     new List<TypedAuraExpression>(),
@@ -165,9 +169,11 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<TypedParamType>
+                                new List<TypedParam>
                                 {
-                                    new TypedParamType(new Int(), false, null)
+                                    new(
+                                        new Tok(TokType.Identifier, "i", 1),
+                                        new TypedParamType(new Int(), false, null))
                                 },
                                 new Nil())),
                         1),
@@ -194,10 +200,14 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<TypedParamType>
+                                new List<TypedParam>
                                 {
-                                    new(new Int(), false, null),
-                                    new(new AuraString(), false, null)
+                                    new(
+                                        new Tok(TokType.Identifier, "i", 1),
+                                        new TypedParamType(new Int(), false, null)),
+                                    new(
+                                        new Tok(TokType.Identifier, "s", 1),
+                                        new TypedParamType(new AuraString(), false, null))
                                 },
                                 new Nil())),
                         1),
@@ -615,7 +625,7 @@ public class CompilerTest
                         new Function(
                             "f",
                             new AnonymousFunction(
-                                new List<TypedParamType>(),
+                                new List<TypedParam>(),
                                 new Nil())),
                         1),
                     new List<TypedAuraExpression>(),

--- a/AuraLang.Test/Parser/ParserTest.cs
+++ b/AuraLang.Test/Parser/ParserTest.cs
@@ -88,7 +88,7 @@ public class ParserTest
 		});
 		MakeAssertions(untypedAst, new UntypedExpressionStmt(
 			new UntypedCall(new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-			new List<UntypedAuraExpression>(), 1),
+			new List<(Tok?, UntypedAuraExpression)>(), 1),
 			1));
 	}
 
@@ -480,7 +480,7 @@ public class ParserTest
 		MakeAssertions(untypedAst, new UntypedDefer(
 			new UntypedCall(
 				new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-				new List<UntypedAuraExpression>(),
+				new List<(Tok?, UntypedAuraExpression)>(),
 				1),
 			1));
 	}

--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -138,7 +138,7 @@ public class TypeCheckerTest
             new Function(
                 "f",
                 new AnonymousFunction(
-                    new List<TypedParamType>(),
+                    new List<TypedParam>(),
                     new Nil())),
             1,
             "main"));
@@ -157,7 +157,7 @@ public class TypeCheckerTest
             new TypedCall(
                 new TypedVariable(
                     new Tok(TokType.Identifier, "f", 1),
-                    new Function("f", new AnonymousFunction(new List<TypedParamType>(), new Nil())),
+                    new Function("f", new AnonymousFunction(new List<TypedParam>(), new Nil())),
                     1),
                 new List<TypedAuraExpression>(),
                 new Nil(),
@@ -662,7 +662,7 @@ public class TypeCheckerTest
                 new Function(
                     "f",
                     new AnonymousFunction(
-                        new List<TypedParamType>(),
+                        new List<TypedParam>(),
                         new Nil())),
                 1,
                 "main"));
@@ -685,7 +685,7 @@ public class TypeCheckerTest
                     new Function(
                         "f",
                         new AnonymousFunction(
-                            new List<TypedParamType>(),
+                            new List<TypedParam>(),
                             new Nil())),
                     1),
                 new List<TypedAuraExpression>(),

--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -149,7 +149,7 @@ public class TypeCheckerTest
                 new UntypedExpressionStmt(
                     new UntypedCall(
                         new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-                        new List<UntypedAuraExpression>(),
+                        new List<(Tok?, UntypedAuraExpression)>(),
                         1),
                     1)
             });
@@ -674,7 +674,7 @@ public class TypeCheckerTest
                     new UntypedVariable(
                         new Tok(TokType.Identifier, "f", 1),
                         1),
-                    new List<UntypedAuraExpression>(),
+                    new List<(Tok?, UntypedAuraExpression)>(),
                     1),
                 1)
         });

--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -162,7 +162,64 @@ public class TypeCheckerTest
                 new List<TypedAuraExpression>(),
                 new Nil(),
                 1),
-            1)) ;
+            1));
+    }
+
+    [Test]
+    public void TestTypeCheck_TwoArgs_WithTags()
+    {
+        _currentModuleStore.Setup(cms => cms.GetName())
+            .Returns("main");
+        _variableStore.Setup(v => v.Find("f", "main")).Returns(new Local(
+            "f",
+            new Function(
+                "f",
+                new AnonymousFunction(
+                    new List<TypedParam>
+                    {
+                        new(
+                            new Tok(TokType.Identifier, "i", 1),
+                            new TypedParamType(new Int(), false, null)),
+                        new(
+                            new Tok(TokType.Identifier, "s", 1),
+                            new TypedParamType(new AuraString(), false, null))
+                    },
+                    new Nil())),
+            1,
+            "main"));
+        
+        var typedAst = ArrangeAndAct(
+            new List<UntypedAuraStatement>
+            {
+                new UntypedExpressionStmt(
+                    new UntypedCall(
+                        new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
+                        new List<(Tok?, UntypedAuraExpression)>
+                        {
+                            (
+                                new Tok(TokType.Identifier, "s", 1),
+                                new UntypedStringLiteral("Hello world", 1)),
+                            (
+                                new Tok(TokType.Identifier, "i", 1),
+                                new UntypedIntLiteral(5, 1))
+                        },
+                        1),
+                    1)
+            });
+        MakeAssertions(typedAst,  new TypedExpressionStmt(
+            new TypedCall(
+                new TypedVariable(
+                    new Tok(TokType.Identifier, "f", 1),
+                    new Function("f", new AnonymousFunction(new List<TypedParam>(), new Nil())),
+                    1),
+                new List<TypedAuraExpression>
+                {
+                    new TypedLiteral<long>(5, new Int(), 1),
+                    new TypedLiteral<string>("Hello world", new AuraString(), 1)
+                },
+                new Nil(),
+                1),
+            1));
     }
 
     [Test]

--- a/AuraLang/AST/UntypedAst.cs
+++ b/AuraLang/AST/UntypedAst.cs
@@ -69,9 +69,13 @@ public record UntypedBlock(List<UntypedAuraStatement> Statements, int Line) : Un
 /// Represents a function call
 /// </summary>
 /// <param name="Callee">The expression being called</param>
-/// <param name="Arguments">The call's arguments</param>
+/// <param name="Arguments">The call's arguments. Each argument is a tuple containing an optional tag and the argument's value.
+/// An argument's tag must precede the argument's value, and the two are separated by a colon. The tag must match the name
+/// of one of the function's parameters. Tags can be used to specify arguments in a different order than the function's parameters
+/// were defined. For example, the stdlib's <c>printf</c> function could be called with tags like so:
+/// <code>printf(a: 5, format: "%d\n")</code></param>
 public record UntypedCall
-    (IUntypedAuraCallable Callee, List<UntypedAuraExpression> Arguments, int Line) : UntypedAuraExpression(Line),
+    (IUntypedAuraCallable Callee, List<(Tok?, UntypedAuraExpression)> Arguments, int Line) : UntypedAuraExpression(Line),
         IUntypedAuraCallable
 {
     public string GetName() => Callee.GetName();

--- a/AuraLang/Parser/Parser.cs
+++ b/AuraLang/Parser/Parser.cs
@@ -755,17 +755,25 @@ public class AuraParser
     private UntypedAuraExpression FinishCall(UntypedAuraExpression callee)
     {
         var line = Previous().Line;
-        var arguments = new List<UntypedAuraExpression>();
+        var arguments = new List<(Tok?, UntypedAuraExpression)>();
         if (!Check(TokType.RightParen))
         {
             while (true)
             {
                 // Function declarations have a max of 255 arguments, so function calls have the same limit
                 if (arguments.Count >= 255) throw new TooManyParametersException(Peek().Line);
+
+                Tok? tag = null;
+                if (PeekNext().Typ is TokType.Colon)
+                {
+                    tag = Advance();
+                    Consume(TokType.Colon, new ExpectColonException(Peek().Line));
+                }
+                
                 var expression = Expression();
-                arguments.Add(expression);
+                arguments.Add((tag, expression));
                 if (Check(TokType.RightParen)) break;
-                else Match(TokType.Comma);
+                Match(TokType.Comma);
             }
         }
 

--- a/AuraLang/Stdlib/Stdlib.cs
+++ b/AuraLang/Stdlib/Stdlib.cs
@@ -15,19 +15,25 @@ public class AuraStdlib
             new(
                 "println",
                 new AnonymousFunction(
-                    new List<TypedParamType>
-                    {
-                        new(new AuraString(), false, null)
+                    new List<TypedParam>
+                    { 
+                        new(
+                            new Tok(TokType.Identifier, "s", 1),
+                            new TypedParamType(new AuraString(), false, null))
                     },
                     new Nil())
                 ),
             new(
                 "printf",
                 new AnonymousFunction(
-                    new List<TypedParamType>
+                    new List<TypedParam>
                     {
-                        new(new AuraString(), false, null),
-                        new(new Any(), true, null)
+                        new(
+                            new Tok(TokType.Identifier, "format", 1),
+                            new TypedParamType(new AuraString(), false, null)),
+                        new(
+                            new Tok(TokType.Identifier, "a", 1),
+                            new TypedParamType(new Any(), true, null))
                     },
                     new Nil())
                 )

--- a/AuraLang/TypeChecker/TypeChecker.cs
+++ b/AuraLang/TypeChecker/TypeChecker.cs
@@ -644,7 +644,7 @@ public class AuraTypeChecker
             // Type check arguments
             var typedArgs = call.Arguments
                 .Zip(funcDeclaration.GetParamTypes())
-                .Select(pair => ExpressionAndConfirm(pair.First, pair.Second.Typ))
+                .Select(pair => ExpressionAndConfirm(pair.First.Item2, pair.Second.Typ))
                 .ToList();
             return new TypedCall(typedCallee!, typedArgs, funcDeclaration.GetReturnType(), call.Line);
         }, call);

--- a/AuraLang/TypeChecker/TypeChecker.cs
+++ b/AuraLang/TypeChecker/TypeChecker.cs
@@ -642,7 +642,7 @@ public class AuraTypeChecker
             // Ensure the function call has the correct number of arguments
             if (funcDeclaration!.GetParamTypes().Count != call.Arguments.Count) throw new IncorrectNumberOfArgumentsException(call.Line);
             // Type check arguments
-            var typedArgs = new List<TypedAuraExpression>();
+            var typedArgs = new List<TypedAuraExpression>(call.Arguments.Count);
             foreach (var arg in call.Arguments.Zip(funcDeclaration.GetParamTypes()))
             {
                 if (arg.First.Item1 is null)

--- a/AuraLang/Types/AuraType.cs
+++ b/AuraLang/Types/AuraType.cs
@@ -148,8 +148,9 @@ public class Function : AuraType, ICallable
     {
         return other is Function;
     }
-
+    
     public override string ToString() => "function";
+    public List<TypedParam> GetParams() => F.Params;
     public List<TypedParamType> GetParamTypes() => F.Params.Select(p => p.ParamType).ToList();
     public AuraType GetReturnType() => F.ReturnType;
     public int GetParamIndex(string name) => F.Params.FindIndex(p => p.Name.Value == name);
@@ -183,6 +184,7 @@ public class AnonymousFunction : AuraType, ICallable
         return $"fn({pt}) -> {ReturnType}";
     }
 
+    public List<TypedParam> GetParams() => Params;
     public List<TypedParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
     public AuraType GetReturnType() => ReturnType;
     public int GetParamIndex(string name) => Params.FindIndex(p => p.Name.Value == name);

--- a/AuraLang/Types/AuraType.cs
+++ b/AuraLang/Types/AuraType.cs
@@ -150,8 +150,9 @@ public class Function : AuraType, ICallable
     }
 
     public override string ToString() => "function";
-    public List<TypedParamType> GetParamTypes() => F.ParamTypes;
+    public List<TypedParamType> GetParamTypes() => F.Params.Select(p => p.ParamType).ToList();
     public AuraType GetReturnType() => F.ReturnType;
+    public int GetParamIndex(string name) => F.Params.FindIndex(p => p.Name.Value == name);
 }
 
 /// <summary>
@@ -160,12 +161,12 @@ public class Function : AuraType, ICallable
 /// </summary>
 public class AnonymousFunction : AuraType, ICallable
 {
-    public List<TypedParamType> ParamTypes { get; }
+    public List<TypedParam> Params { get; }
     public AuraType ReturnType { get; }
 
-    public AnonymousFunction(List<TypedParamType> paramTypes, AuraType returnType)
+    public AnonymousFunction(List<TypedParam> fParams, AuraType returnType)
     {
-        ParamTypes = paramTypes;
+        Params = fParams;
         ReturnType = returnType;
     }
 
@@ -176,14 +177,15 @@ public class AnonymousFunction : AuraType, ICallable
 
     public override string ToString()
     {
-        var pt = ParamTypes
+        var pt = Params
             .Select(p => p.ToString())
             .Aggregate("", (prev, curr) => $"{prev}, {curr}");
         return $"fn({pt}) -> {ReturnType}";
     }
 
-    public List<TypedParamType> GetParamTypes() => ParamTypes;
+    public List<TypedParamType> GetParamTypes() => Params.Select(p => p.ParamType).ToList();
     public AuraType GetReturnType() => ReturnType;
+    public int GetParamIndex(string name) => Params.FindIndex(p => p.Name.Value == name);
 }
 
 /// <summary>

--- a/AuraLang/Types/ICallable.cs
+++ b/AuraLang/Types/ICallable.cs
@@ -6,5 +6,6 @@ public interface ICallable
 {
     List<TypedParamType> GetParamTypes();
     AuraType GetReturnType();
+    int GetParamIndex(string name);
 }
 

--- a/AuraLang/Types/ICallable.cs
+++ b/AuraLang/Types/ICallable.cs
@@ -4,6 +4,7 @@ namespace AuraLang.Types;
 
 public interface ICallable
 {
+    List<TypedParam> GetParams();
     List<TypedParamType> GetParamTypes();
     AuraType GetReturnType();
     int GetParamIndex(string name);


### PR DESCRIPTION
* When calling a function, you can specify the arguments out of order if you tag the arguments with their parameter name, like so:
```
fn f(i: int, s: string) { ... }

f(s: "Hello world", i: 0)
```