### PR TITLE
Don't throw exception in variable store

### DIFF
--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -30,7 +30,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Assignment()
 	{
-		_variableStore.Setup(v => v.Find("i", It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("i", It.IsAny<string>()))
 			.Returns(new Local("i", new Int(), 1, null));
 
 		var typedAst = ArrangeAndAct(
@@ -132,7 +132,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Call_NoArgs()
 	{
-		_variableStore.Setup(v => v.Find("f", null, 1, It.IsAny<string>())).Returns(new Local(
+		_variableStore.Setup(v => v.Find("f", null)).Returns(new Local(
 			"f",
 			new NamedFunction(
 				"f",
@@ -168,7 +168,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_TwoArgs_WithTags()
 	{
-		_variableStore.Setup(v => v.Find("f", null, 1, It.IsAny<string>())).Returns(new Local(
+		_variableStore.Setup(v => v.Find("f", null)).Returns(new Local(
 			"f",
 			new NamedFunction(
 				"f",
@@ -220,7 +220,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Call_DefaultValues()
 	{
-		_variableStore.Setup(v => v.Find("f", null, 1, It.IsAny<string>())).Returns(new Local(
+		_variableStore.Setup(v => v.Find("f", null)).Returns(new Local(
 			"f",
 			new NamedFunction(
 				"f",
@@ -269,7 +269,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Call_NoValueForParameterWithoutDefaultValue()
 	{
-		_variableStore.Setup(v => v.Find("f", null, 1, It.IsAny<string>())).Returns(new Local(
+		_variableStore.Setup(v => v.Find("f", null)).Returns(new Local(
 			"f",
 			new NamedFunction(
 				"f",
@@ -307,7 +307,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Call_MixNamedAndUnnamedArguments()
 	{
-		_variableStore.Setup(v => v.Find("f", null, 1, It.IsAny<string>())).Returns(new Local(
+		_variableStore.Setup(v => v.Find("f", null)).Returns(new Local(
 			"f",
 			new NamedFunction(
 				"f",
@@ -348,7 +348,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Get()
 	{
-		_variableStore.Setup(v => v.Find("greeter", null, 1, It.IsAny<string>())).Returns(
+		_variableStore.Setup(v => v.Find("greeter", null)).Returns(
 			new Local(
 				"greeter",
 				new Class(
@@ -401,7 +401,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_GetIndex()
 	{
-		_variableStore.Setup(v => v.Find("names", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("names", null))
 			.Returns(new Local(
 				"names",
 				new AuraList(new AuraString()),
@@ -434,7 +434,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_GetIndexRange()
 	{
-		_variableStore.Setup(v => v.Find("names", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("names", null))
 			.Returns(new Local(
 				"names",
 				new AuraList(new AuraString()),
@@ -671,7 +671,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Set()
 	{
-		_variableStore.Setup(v => v.Find("greeter", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("greeter", null))
 			.Returns(new Local(
 				"greeter",
 				new Class(
@@ -806,7 +806,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Variable()
 	{
-		_variableStore.Setup(v => v.Find("name", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("name", null))
 			.Returns(new Local(
 				"name",
 				new AuraString(),
@@ -832,7 +832,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Defer()
 	{
-		_variableStore.Setup(v => v.Find("f", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("f", null))
 			.Returns(new Local(
 				"f",
 				new NamedFunction(
@@ -875,7 +875,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_For_EmptyBody()
 	{
-		_variableStore.Setup(v => v.Find("i", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("i", null))
 			.Returns(new Local(
 				"i",
 				new Int(),
@@ -924,7 +924,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_ForEach_EmptyBody()
 	{
-		_variableStore.Setup(v => v.Find("names", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("names", null))
 			.Returns(new Local(
 				"names",
 				new AuraList(new AuraString()),
@@ -1309,13 +1309,13 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_ClassImplementingTwoInterfaces_NoMethods()
 	{
-		_variableStore.Setup(v => v.Find("IGreeter", null, It.IsAny<int>(), It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("IGreeter", null))
 			.Returns(new Local(
 				"IGreeter",
 				new Interface("IGreeter", new List<NamedFunction>(), Visibility.Private),
 				1,
 				null));
-		_variableStore.Setup(v => v.Find("IGreeter2", null, It.IsAny<int>(), It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("IGreeter2", null))
 			.Returns(new Local(
 				"IGreeter2",
 				new Interface("IGreeter2", new List<NamedFunction>(), Visibility.Private),
@@ -1348,7 +1348,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_ClassImplementingInterface_NoMethods()
 	{
-		_variableStore.Setup(v => v.Find("IGreeter", null, It.IsAny<int>(), It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("IGreeter", null))
 			.Returns(new Local(
 				"IGreeter",
 				new Interface("IGreeter", new List<NamedFunction>(), Visibility.Private),
@@ -1377,7 +1377,7 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Set_Invalid()
 	{
-		_variableStore.Setup(v => v.Find("v", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("v", null))
 			.Returns(new Local(
 				"v",
 				new Int(),
@@ -1403,17 +1403,10 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Is()
 	{
-		_variableStore.Setup(v => v.Find("v", null, 1, It.IsAny<string>()))
+		_variableStore.Setup(v => v.Find("v", null))
 			.Returns(new Local(
 				"v",
 				new Int(),
-				1,
-				null));
-		_variableStore.Setup(v =>
-				v.FindAndConfirm("IGreeter", null, It.IsAny<Interface>(), It.IsAny<int>(), It.IsAny<string>()))
-			.Returns(new Local(
-				"IGreeter",
-				new Interface("IGreeter", new List<NamedFunction>(), Visibility.Private),
 				1,
 				null));
 

--- a/AuraLang/TypeChecker/TypeChecker.cs
+++ b/AuraLang/TypeChecker/TypeChecker.cs
@@ -473,9 +473,9 @@ public class AuraTypeChecker
 				? class_.Implementing.Select(impl =>
 				{
 					var local = _variableStore.Find(impl.Value, null) ??
-					            throw new UnknownVariableException(FilePath, class_.Line);
+								throw new UnknownVariableException(FilePath, class_.Line);
 					var i = local.Kind as Interface ??
-					        throw new CannotImplementNonInterfaceException(FilePath, class_.Line);
+							throw new CannotImplementNonInterfaceException(FilePath, class_.Line);
 					return i;
 				})
 				: new List<Interface>();
@@ -730,7 +730,7 @@ public class AuraTypeChecker
 		{
 			// Fetch the variable being assigned to
 			var v = _variableStore.Find(assignment.Name.Value, null) ??
-			        throw new UnknownVariableException(FilePath, assignment.Line);
+					throw new UnknownVariableException(FilePath, assignment.Line);
 			// Ensure that the new value and the variable have the same type
 			var typedExpr = ExpressionAndConfirm(assignment.Value, v.Kind);
 			return new TypedAssignment(assignment.Name, typedExpr, typedExpr.Typ, assignment.Line);
@@ -800,7 +800,7 @@ public class AuraTypeChecker
 		return _enclosingExpressionStore.WithEnclosing(() =>
 		{
 			var f = _variableStore.Find(call.Callee.GetName(), null) ??
-			        throw new UnknownVariableException(FilePath, call.Line);
+					throw new UnknownVariableException(FilePath, call.Line);
 			var funcDeclaration = f.Kind as ICallable;
 			// Type check arguments
 			if (call.Arguments.Any())
@@ -827,8 +827,8 @@ public class AuraTypeChecker
 				{
 					var index = funcDeclaration.GetParamIndex(arg.Name.Value);
 					var defaultValue = arg.ParamType.DefaultValue ??
-					                   throw new MustSpecifyValueForArgumentWithoutDefaultValueException(FilePath,
-						                   call.Line);
+									   throw new MustSpecifyValueForArgumentWithoutDefaultValueException(FilePath,
+										   call.Line);
 					if (index >= typedArgs.Count) typedArgs.Add(defaultValue);
 					else typedArgs.Insert(index, defaultValue);
 				}
@@ -1194,7 +1194,7 @@ public class AuraTypeChecker
 		{
 			var index = declaration.GetParamIndex(missingParam.Name.Value);
 			var defaultValue = missingParam.ParamType.DefaultValue ??
-			                   throw new MustSpecifyValueForArgumentWithoutDefaultValueException(FilePath, call.Line);
+							   throw new MustSpecifyValueForArgumentWithoutDefaultValueException(FilePath, call.Line);
 			if (index >= orderedArgs.Count) typedArgs.Add((ITypedAuraExpression)defaultValue);
 			else typedArgs.Insert(index, (ITypedAuraExpression)defaultValue);
 		}

--- a/AuraLang/TypeChecker/VariableStore.cs
+++ b/AuraLang/TypeChecker/VariableStore.cs
@@ -20,19 +20,7 @@ public interface IVariableStore
 	/// <param name="varName">The name of the variable</param>
 	/// <param name="modName">The name of the module where the variable was originally defined</param>
 	/// <returns>The existing local variable, if it exists, else null</returns>
-	Local Find(string varName, string? modName, int line, string filePath);
-
-	/// <summary>
-	/// Find an existing local variable, if it exists, and confirm it matches the expected type
-	/// </summary>
-	/// <param name="varName">The name of the variable</param>
-	/// <param name="modName">The name of the module where the variable was originally defined</param>
-	/// <param name="expected">The expected type of the variable</param>
-	/// <param name="line">The line where the variable is being fetched from. Used in the exceptions, if any are thrown.</param>
-	/// <exception cref="UnknownVariableException">Thrown if the local variable doesn't exist</exception>
-	/// <exception cref="UnexpectedTypeException">Thrown if the local variable doesn't match the expected type</exception>
-	/// <returns>The local variable, if it exists and matches the expected type</returns>
-	Local FindAndConfirm(string varName, string? modName, AuraType expected, int line, string filePath);
+	Local? Find(string varName, string? modName);
 
 	/// <summary>
 	/// Clears all local variables that were defined in the specified scope
@@ -47,22 +35,12 @@ public class VariableStore : IVariableStore
 
 	public void Add(Local local) => _variables.Add(local);
 
-	public Local Find(string varName, string? modName, int line, string filePath)
+	public Local? Find(string varName, string? modName)
 	{
-		var local = _variables.Find(v =>
-		{
-			return v.Name == varName &&
-				   (v.Defining is null && modName is null ||
-					v.Defining == modName);
-		});
-		if (local.Equals(default)) throw new UnknownVariableException(filePath, line);
-		return local;
-	}
-
-	public Local FindAndConfirm(string varName, string? modName, AuraType expected, int line, string filePath)
-	{
-		var local = Find(varName, modName, line, filePath);
-		if (!expected.IsSameOrInheritingType(local.Kind)) throw new UnexpectedTypeException(filePath, line);
+		var local = _variables.Find(v => v.Name == varName &&
+		                                 (v.Defining is null && modName is null ||
+		                                  v.Defining == modName));
+		if (local.Equals(default)) return null;
 		return local;
 	}
 

--- a/AuraLang/TypeChecker/VariableStore.cs
+++ b/AuraLang/TypeChecker/VariableStore.cs
@@ -38,8 +38,8 @@ public class VariableStore : IVariableStore
 	public Local? Find(string varName, string? modName)
 	{
 		var local = _variables.Find(v => v.Name == varName &&
-		                                 (v.Defining is null && modName is null ||
-		                                  v.Defining == modName));
+										 (v.Defining is null && modName is null ||
+										  v.Defining == modName));
 		if (local.Equals(default)) return null;
 		return local;
 	}


### PR DESCRIPTION
* Throwing an exception in the Variable Store requires extra parameters to be passed into its functions that are used only in the exception's constructor. Instead, move the exception throwing logic back into the Type Checker