### PR TITLE
Override `Execute()` in `New` CLI command

### DIFF
--- a/AuraLang.Cli/Commands/AuraCommand.cs
+++ b/AuraLang.Cli/Commands/AuraCommand.cs
@@ -22,7 +22,7 @@ public abstract class AuraCommand
 		Verbose = opts.Verbose ?? false;
 	}
 
-	public int Execute()
+	public virtual int Execute()
 	{
 		try
 		{

--- a/AuraLang.Cli/Commands/New.cs
+++ b/AuraLang.Cli/Commands/New.cs
@@ -16,6 +16,8 @@ public class New : AuraCommand
 		Name = opts.Name!;
 	}
 
+	public override int Execute() => ExecuteCommand();
+
 	/// <summary>
 	/// Creates a new Aura project
 	/// </summary>


### PR DESCRIPTION
* `aura new` is the only command that shouldn't check for the `aura.toml` file in the project's root (since the project doesn't yet exist - it will be created by the `aura new` command)
* Make the `Execute()` method virtual so that the `New` command can override the default implementation and skip the `aura.toml` check