### PR TITLE
Ensure new parent directory is empty

### DIFF
--- a/AuraLang.Cli/Commands/New.cs
+++ b/AuraLang.Cli/Commands/New.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using AuraLang.Cli.Exceptions;
 using AuraLang.Cli.Options;
 using AuraLang.Cli.Toml;
 
@@ -21,7 +22,18 @@ public class New : AuraCommand
 		ProjectDirectory = opts.OutputPath;
 	}
 
-	public override int Execute() => ExecuteCommand();
+	public override int Execute()
+	{
+		try
+		{
+			return ExecuteCommand();
+		}
+		catch (NewParentDirectoryMustBeEmpty ex)
+		{
+			Console.WriteLine(ex.Message);
+			return 1;
+		}
+	}
 
 	/// <summary>
 	/// Creates a new Aura project
@@ -33,6 +45,9 @@ public class New : AuraCommand
 		var projPath = $"{projDir}/{Name}";
 
 		Directory.CreateDirectory(projPath);
+		// Ensure that the project's parent directory is empty
+		if (Directory.GetFileSystemEntries(projPath).Length > 0) throw new NewParentDirectoryMustBeEmpty();
+
 		Directory.CreateDirectory($"{projPath}/src");
 		File.WriteAllText($"{projPath}/src/{Name}.aura", "mod main\n\nimport aura/io\n\nfn main() {\n\tio.println(\"Hello world!\")\n}\n");
 		Directory.CreateDirectory($"{projPath}/test");

--- a/AuraLang.Cli/Exceptions/CliExceptions.cs
+++ b/AuraLang.Cli/Exceptions/CliExceptions.cs
@@ -4,3 +4,8 @@ public class TomlFileNotFoundException : Exception
 {
 	public TomlFileNotFoundException() : base("aura.toml file not found in current directory or any parent directories.") { }
 }
+
+public class NewParentDirectoryMustBeEmpty : Exception
+{
+	public NewParentDirectoryMustBeEmpty() : base("The project's parent directory must be empty.") { }
+}


### PR DESCRIPTION
* When creating a new Aura project with `aura new`, the new project must be placed into an empty directory
* If the directory is not empty, `aura new` will fail