### PR TITLE
Add imported module interface

### DIFF
--- a/AuraLang.Lsp/DocumentManager/DocumentManager.cs
+++ b/AuraLang.Lsp/DocumentManager/DocumentManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using AuraLang.AST;
 using AuraLang.Exceptions;
+using AuraLang.Lsp.SynchronizedFileProvider;
 using AuraLang.Parser;
 using AuraLang.Scanner;
 using AuraLang.Stores;
@@ -34,6 +35,7 @@ public class AuraDocumentManager
 				new EnclosingFunctionDeclarationStore(),
 				new EnclosingNodeStore<IUntypedAuraExpression>(),
 				new EnclosingNodeStore<IUntypedAuraStatement>(),
+				new AuraSynchronizedFileProvider(this),
 				path,
 				"Test Project Name");
 			typeChecker.BuildSymbolsTable(untypedAst);
@@ -74,6 +76,15 @@ public class AuraDocumentManager
 	{
 		var (module, file) = GetModuleAndFileNames(path);
 		return _documents[module][file];
+	}
+
+	public List<(string, string)> GetModule(string module)
+	{
+		if (_documents.TryGetValue(module, out var value))
+		{
+			return value.Select(item => (item.Key, item.Value)).ToList();
+		}
+		return new List<(string, string)>();
 	}
 
 	private (string, string) GetModuleAndFileNames(string path)

--- a/AuraLang.Lsp/SynchronizedFileProvider/SynchronizedFileProvider.cs
+++ b/AuraLang.Lsp/SynchronizedFileProvider/SynchronizedFileProvider.cs
@@ -1,0 +1,19 @@
+﻿using AuraLang.ImportedFileProvider;
+using AuraLang.Lsp.DocumentManager;
+
+namespace AuraLang.Lsp.SynchronizedFileProvider;
+
+public class AuraSynchronizedFileProvider : IImportedModuleProvider
+{
+	private AuraDocumentManager _documents { get; }
+
+	public AuraSynchronizedFileProvider(AuraDocumentManager documentManager)
+	{
+		_documents = documentManager;
+	}
+
+	public List<(string, string)> GetImportedModule(string moduleName)
+	{
+		return _documents.GetModule(moduleName);
+	}
+}

--- a/AuraLang.Test/Integration/Test/IntegrationTest_SingleFile.cs
+++ b/AuraLang.Test/Integration/Test/IntegrationTest_SingleFile.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using AuraLang.AST;
+using AuraLang.Cli.LocalFileSystemModuleProvider;
 using AuraLang.Exceptions;
 using AuraLang.FileCompiler;
 using AuraLang.Stores;
@@ -121,7 +122,7 @@ public class IntegrationTest_SingleFile
 		var fileName = Path.GetFileNameWithoutExtension(path);
 		var typeChecker = new AuraTypeChecker(new GlobalSymbolsTable(), new EnclosingClassStore(), new EnclosingFunctionDeclarationStore(),
 			new EnclosingNodeStore<IUntypedAuraExpression>(), new EnclosingNodeStore<IUntypedAuraStatement>(),
-			path, "Test");
+			new AuraLocalFileSystemImportedModuleProvider(), path, "Test");
 		var compiler = new AuraFileCompiler(path, "Examples");
 
 		try

--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -1,4 +1,5 @@
 ﻿using AuraLang.AST;
+using AuraLang.Cli.LocalFileSystemModuleProvider;
 using AuraLang.Exceptions.TypeChecker;
 using AuraLang.Shared;
 using AuraLang.Stores;
@@ -1934,7 +1935,7 @@ public class TypeCheckerTest
 
 	private List<ITypedAuraStatement> ArrangeAndAct(List<IUntypedAuraStatement> untypedAst)
 		=> new AuraTypeChecker(_symbolsTable.Object, _enclosingClassStore.Object, _enclosingFunctionDeclarationStore.Object, _enclosingExprStore.Object,
-				_enclosingStmtStore.Object, "Test", "Test")
+				_enclosingStmtStore.Object, new AuraLocalFileSystemImportedModuleProvider(), "Test", "Test")
 			.CheckTypes(AddModStmtIfNecessary(untypedAst));
 
 	private void ArrangeAndAct_Invalid(List<IUntypedAuraStatement> untypedAst, Type expected)
@@ -1942,7 +1943,7 @@ public class TypeCheckerTest
 		try
 		{
 			new AuraTypeChecker(_symbolsTable.Object, _enclosingClassStore.Object, _enclosingFunctionDeclarationStore.Object, _enclosingExprStore.Object,
-					_enclosingStmtStore.Object, "Test", "Test")
+					_enclosingStmtStore.Object, new AuraLocalFileSystemImportedModuleProvider(), "Test", "Test")
 				.CheckTypes(AddModStmtIfNecessary(untypedAst));
 			Assert.Fail();
 		}

--- a/AuraLang/ImportedFileProvider/IImportedFileProvider.cs
+++ b/AuraLang/ImportedFileProvider/IImportedFileProvider.cs
@@ -1,0 +1,18 @@
+﻿namespace AuraLang.ImportedFileProvider;
+
+/// <summary>
+/// Responsible for fetching Aura modules that are imported into an Aura source file via an <c>import</c> statement. The reason this action has been
+/// abstracted into its own interface is because these imported Aura modules are fetched in different ways depending on the execution context. When
+/// running a CLI command, imported Aura modules can be fetched from the local file system. However, the LSP server may be storing Aura modules that
+/// have been synchronized from the client, and it would prefer to provide these synchronized files instead of reading them from the local file system.
+/// </summary>
+public interface IImportedModuleProvider
+{
+	/// <summary>
+	/// Fetches the Aura source file identified by the module and file name
+	/// </summary>
+	/// <param name="moduleName">The name of the imported Aura module</param>
+	/// <returns>A list of tuples, with each tuple containing the source file's name as its first item and the source
+	/// file's contents as its second item</returns>
+	List<(string, string)> GetImportedModule(string moduleName);
+}

--- a/AuraLang/LocalFileSystemModuleProvider/LocalFileSystemModuleProvider.cs
+++ b/AuraLang/LocalFileSystemModuleProvider/LocalFileSystemModuleProvider.cs
@@ -1,0 +1,35 @@
+﻿using AuraLang.ImportedFileProvider;
+
+namespace AuraLang.Cli.LocalFileSystemModuleProvider;
+
+/// <summary>
+/// Responsible for fetching imported Aura files from the local file system
+/// </summary>
+public class AuraLocalFileSystemImportedModuleProvider : IImportedModuleProvider
+{
+	public List<(string, string)> GetImportedModule(string moduleName)
+	{
+		FindProjectRoot();
+		var path = $"./src/{moduleName}";
+		return Directory.GetFiles(path, "*.aura")
+			.Select(p =>
+			{
+				var contents = File.ReadAllText(p);
+				return (p, contents);
+			}).ToList();
+	}
+
+	protected void FindProjectRoot() => FindProjectRootRecur(".");
+
+	private void FindProjectRootRecur(string path)
+	{
+		if (!File.Exists(path))
+		{
+			if (Directory.GetParent(path) is null) throw new Exception(); // TODO create exception
+			FindProjectRootRecur(Directory.GetParent(path)!.FullName);
+			return;
+		}
+
+		Directory.SetCurrentDirectory(path);
+	}
+}

--- a/AuraLang/ModuleCompiler/ModuleCompiler.cs
+++ b/AuraLang/ModuleCompiler/ModuleCompiler.cs
@@ -1,6 +1,8 @@
 ﻿using AuraLang.AST;
+using AuraLang.Cli.LocalFileSystemModuleProvider;
 using AuraLang.Exceptions.TypeChecker;
 using AuraLang.FileCompiler;
+using AuraLang.ImportedFileProvider;
 using AuraLang.Stores;
 using AuraLang.Symbol;
 using AuraLang.TypeChecker;
@@ -13,8 +15,8 @@ public class AuraModuleCompiler
 	/// The path of the module
 	/// </summary>
 	private string Path { get; }
-
 	private string ProjectName { get; }
+	private IImportedModuleProvider _importedModuleProvider { get; }
 
 	/// <summary>
 	/// The same type checker will be used for all Aura source files in the module
@@ -25,12 +27,15 @@ public class AuraModuleCompiler
 	{
 		Path = path;
 		ProjectName = projectName;
+		var importedModuleProvider = new AuraLocalFileSystemImportedModuleProvider();
+		_importedModuleProvider = importedModuleProvider;
 		TypeChecker = new AuraTypeChecker(
 			new GlobalSymbolsTable(),
 			new EnclosingClassStore(),
 			new EnclosingFunctionDeclarationStore(),
 			new EnclosingNodeStore<IUntypedAuraExpression>(),
 			new EnclosingNodeStore<IUntypedAuraStatement>(),
+			importedModuleProvider,
 			path,
 			ProjectName);
 	}
@@ -39,6 +44,7 @@ public class AuraModuleCompiler
 	{
 		Path = path;
 		ProjectName = projectName;
+		_importedModuleProvider = typeChecker._importedFileProvider;
 		TypeChecker = typeChecker;
 	}
 

--- a/AuraLang/TypeChecker/TypeChecker.cs
+++ b/AuraLang/TypeChecker/TypeChecker.cs
@@ -1,5 +1,6 @@
 ﻿using AuraLang.AST;
 using AuraLang.Exceptions.TypeChecker;
+using AuraLang.ImportedFileProvider;
 using AuraLang.ModuleCompiler;
 using AuraLang.Prelude;
 using AuraLang.Shared;
@@ -24,12 +25,13 @@ public class AuraTypeChecker : IUntypedAuraStmtVisitor<ITypedAuraStatement>, IUn
 	private string ProjectName { get; }
 	private string? ModuleName { get; set; }
 	private readonly AuraPrelude _prelude = new();
+	public IImportedModuleProvider _importedFileProvider { get; }
 
 	public AuraTypeChecker(IGlobalSymbolsTable symbolsTable, IEnclosingClassStore enclosingClassStore,
 		IEnclosingFunctionDeclarationStore enclosingFunctionDeclarationStore,
 		EnclosingNodeStore<IUntypedAuraExpression> enclosingExpressionStore,
 		EnclosingNodeStore<IUntypedAuraStatement> enclosingStatementStore,
-		string filePath, string projectName)
+		IImportedModuleProvider importedFileProvider, string filePath, string projectName)
 	{
 		_symbolsTable = symbolsTable;
 		_enclosingClassStore = enclosingClassStore;
@@ -37,6 +39,7 @@ public class AuraTypeChecker : IUntypedAuraStmtVisitor<ITypedAuraStatement>, IUn
 		_enclosingExpressionStore = enclosingExpressionStore;
 		_enclosingStatementStore = enclosingStatementStore;
 		_exContainer = new TypeCheckerExceptionContainer(filePath);
+		_importedFileProvider = importedFileProvider;
 		ProjectName = projectName;
 	}
 


### PR DESCRIPTION
A new interface has been added to abstract the action of retrieving the contents of an imported Aura module. This is because there are two different ways to retrieve the contents:

* The CLI will fetch imported modules from the local file system
* The LSP server will fetch imported modules from the dictionary where it stores files that have been synchronized by the client