### PR TITLE
Add range to AST nodes

### DIFF
--- a/AuraLang.Cli/Commands/Fmt.cs
+++ b/AuraLang.Cli/Commands/Fmt.cs
@@ -244,11 +244,11 @@ public class AuraFmt : AuraCommand, IUntypedAuraStmtVisitor<string>, IUntypedAur
 		return $"if {cond} {then}{elsee}";
 	}
 
-	public string Visit(IntLiteral i) => $"{i.I}";
+	public string Visit(IntLiteral i) => $"{i.Value}";
 
-	public string Visit(FloatLiteral f) => $"{f.F}";
+	public string Visit(FloatLiteral f) => $"{f.Value}";
 
-	public string Visit(StringLiteral s) => $"\"{s.S}\"";
+	public string Visit(StringLiteral s) => $"\"{s.Value}\"";
 
 	public string Visit<U>(ListLiteral<U> l) where U : IAuraAstNode
 	{
@@ -264,11 +264,11 @@ public class AuraFmt : AuraCommand, IUntypedAuraStmtVisitor<string>, IUntypedAur
 		return $"map[{m.KeyType} : {m.ValueType}]{{ {values} }}";
 	}
 
-	public string Visit(BoolLiteral b) => $"{b.B}";
+	public string Visit(BoolLiteral b) => $"{b.Value}";
 
 	public string Visit(UntypedNil n) => "nil";
 
-	public string Visit(CharLiteral c) => $"'{c.C}'";
+	public string Visit(CharLiteral c) => $"'{c.Value}'";
 
 	public string Visit(UntypedLogical lo) => $"{Expression(lo.Left)} {lo.Operator.Value} {Expression(lo.Right)}";
 

--- a/AuraLang.Test/Compiler/CompilerTest.cs
+++ b/AuraLang.Test/Compiler/CompilerTest.cs
@@ -16,16 +16,17 @@ public class CompilerTest
 	[Test]
 	public void TestCompile_Assignment()
 	{
-		var output = ArrangeAndAct(new List<ITypedAuraStatement>
-		{
-			new TypedExpressionStmt(
-				new TypedAssignment(
-					new Tok(TokType.Identifier, "i", 1),
-					new IntLiteral(5, 1),
-					new AuraInt(),
-					1),
-				1)
-		});
+		var output = ArrangeAndAct(
+			typedAst: new List<ITypedAuraStatement>
+			{
+				new TypedExpressionStmt(
+					new TypedAssignment(
+						new Tok(TokType.Identifier, "i", 1),
+						new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
+						new AuraInt(),
+						1),
+					1)
+			});
 		MakeAssertions(output, "i = 5");
 	}
 
@@ -36,9 +37,9 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedBinary(
-					new IntLiteral(5, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 					new Tok(TokType.Plus, "+", 1),
-					new IntLiteral(5, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 					new AuraInt(),
 					1),
 				1)
@@ -53,7 +54,9 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedBlock(
+					new Tok(TokType.LeftBrace, "{", 1),
 					new List<ITypedAuraStatement>(),
+					new Tok(TokType.RightBrace, "}", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -68,16 +71,19 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedBlock(
+					new Tok(TokType.LeftBrace, "{", 1),
 					new List<ITypedAuraStatement>
 					{
 						new TypedLet(
+							Let: new Tok(TokType.Let, "let", 1),
 							Names: new List<Tok>{ new(TokType.Identifier, "i", 2) },
 							TypeAnnotation: true,
 							Mutable: false,
-							Initializer: new IntLiteral(5, 2),
+							Initializer: new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 2),
 							Line: 2
 						),
 					},
+					new Tok(TokType.RightBrace, "}", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -131,7 +137,8 @@ public class CompilerTest
 								},
 								new AuraNil())),
 						1),
-					new List<ITypedAuraExpression> { new StringLiteral("Hello world", 1) },
+					new List<ITypedAuraExpression> { new StringLiteral(new Tok(TokType.StringLiteral, "Hello world", 1), 1) },
+					new Tok(TokType.RightParen, ")", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -156,6 +163,7 @@ public class CompilerTest
 								new AuraNil())),
 						1),
 					new List<ITypedAuraExpression>(),
+					new Tok(TokType.RightParen, ")", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -184,7 +192,8 @@ public class CompilerTest
 								},
 								new AuraNil())),
 						1),
-					new List<ITypedAuraExpression> { new IntLiteral(5, 1) },
+					new List<ITypedAuraExpression> { new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1) },
+					new Tok(TokType.RightParen, ")", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -216,7 +225,8 @@ public class CompilerTest
 								},
 								new AuraNil())),
 						1),
-					new List<ITypedAuraExpression> { new IntLiteral(5, 1), new StringLiteral("Hello world", 1) },
+					new List<ITypedAuraExpression> { new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1), new StringLiteral(new Tok(TokType.StringLiteral, "Hello world", 1), 1) },
+					new Tok(TokType.RightParen, ")", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -264,7 +274,8 @@ public class CompilerTest
 						new Tok(TokType.Identifier, "names", 1),
 						new Types.AuraList(new AuraString()),
 						1),
-					new IntLiteral(0, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "0", 1), 1),
+					new Tok(TokType.RightBracket, "]", 1),
 					new AuraString(),
 					1),
 				1)
@@ -283,8 +294,9 @@ public class CompilerTest
 						new Tok(TokType.Identifier, "names", 1),
 						new Types.AuraList(new AuraString()),
 						1),
-					new IntLiteral(0, 1),
-					new IntLiteral(2, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "0", 1), 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "2", 1), 1),
+					new Tok(TokType.RightBracket, "]", 1),
 					new Types.AuraList(new AuraString()),
 					1),
 				1)
@@ -299,7 +311,9 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedGrouping(
-					new StringLiteral("Hello world", 1),
+					new Tok(TokType.LeftParen, "(", 1),
+					new StringLiteral(new Tok(TokType.StringLiteral, "Hello world", 1), 1),
+					new Tok(TokType.RightParen, ")", 1),
 					new AuraString(),
 					1),
 				1)
@@ -314,14 +328,18 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedIf(
-					new BoolLiteral(true, 1),
+					new Tok(TokType.If, "if", 1),
+					new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 					new TypedBlock(
+						new Tok(TokType.LeftBrace, "{", 1),
 						new List<ITypedAuraStatement>
 						{
 							new TypedReturn(
-								new IntLiteral(1, 2),
+								new Tok(TokType.Return, "return", 1),
+								new IntLiteral(new Tok(TokType.IntLiteral, "1", 2), 2),
 								2)
 						},
+						new Tok(TokType.RightBrace, "}", 1),
 						new AuraInt(),
 						1),
 					null,
@@ -339,23 +357,30 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedIf(
-					new BoolLiteral(true, 1),
+					new Tok(TokType.If, "if", 1),
+					new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 					new TypedBlock(
+						new Tok(TokType.LeftBrace, "{", 1),
 						new List<ITypedAuraStatement>
 						{
 							new TypedReturn(
-								new IntLiteral(1, 2),
+								new Tok(TokType.Return, "return", 1),
+								new IntLiteral(new Tok(TokType.IntLiteral, "1", 1), 2),
 								2)
 						},
+						new Tok(TokType.RightBrace, "}", 1),
 						new AuraInt(),
 						1),
 					new TypedBlock(
+						new Tok(TokType.LeftBrace, "{", 1),
 						new List<ITypedAuraStatement>
 						{
 							new TypedReturn(
-								new IntLiteral(2, 4),
+								new Tok(TokType.Return, "return", 1),
+								new IntLiteral(new Tok(TokType.IntLiteral, "2", 1), 4),
 								2)
 						},
+						new Tok(TokType.RightBrace, "}", 1),
 						new AuraInt(),
 						3),
 					new AuraInt(),
@@ -371,7 +396,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new IntLiteral(5, 1),
+				new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "5");
@@ -383,7 +408,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new FloatLiteral(5.1, 1),
+				new FloatLiteral(new Tok(TokType.FloatLiteral, "5.1", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "5.1");
@@ -395,7 +420,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new FloatLiteral(5.0, 1),
+				new FloatLiteral(new Tok(TokType.FloatLiteral, "5.0", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "5.0");
@@ -407,7 +432,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new StringLiteral("Hello world", 1),
+				new StringLiteral(new Tok(TokType.StringLiteral, "Hello world", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "\"Hello world\"");
@@ -416,12 +441,14 @@ public class CompilerTest
 	[Test]
 	public void TestCompile_ListLiteral()
 	{
-		var output = ArrangeAndAct(new System.Collections.Generic.List<ITypedAuraStatement>
+		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
 				new ListLiteral<ITypedAuraExpression>(
-					new List<ITypedAuraExpression> { new IntLiteral(1, 1), new IntLiteral(2, 1), new IntLiteral(3, 1) },
+					new Tok(TokType.LeftBrace, "{", 1),
+					new List<ITypedAuraExpression> { new IntLiteral(new Tok(TokType.IntLiteral, "1", 1), 1), new IntLiteral(new Tok(TokType.IntLiteral, "2", 1), 1), new IntLiteral(new Tok(TokType.IntLiteral, "3", 1), 1) },
 					new AuraInt(),
+					new Tok(TokType.RightBrace, "}", 1),
 					1),
 				1)
 		});
@@ -435,12 +462,14 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
+					new Tok(TokType.Map, "map", 1),
 					new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
 					{
-						{ new StringLiteral("Hello", 1), new IntLiteral(1, 1) }
+						{ new StringLiteral(new Tok(TokType.StringLiteral, "Hello", 1), 1), new IntLiteral(new Tok(TokType.IntLiteral, "1", 1), 1) }
 					},
 					new AuraString(),
 					new AuraInt(),
+					new Tok(TokType.RightBrace, "}", 1),
 					1),
 				1)
 		});
@@ -454,9 +483,11 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
+					new Tok(TokType.Map, "map", 1),
 					new Dictionary<ITypedAuraExpression, ITypedAuraExpression>(),
 					new AuraString(),
 					new AuraInt(),
+					new Tok(TokType.RightBrace, "}", 1),
 					1),
 				1)
 		});
@@ -469,7 +500,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new BoolLiteral(true, 1),
+				new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "true");
@@ -481,7 +512,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new TypedNil(1),
+				new TypedNil(new Tok(TokType.Nil, "nil", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "nil");
@@ -493,7 +524,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedExpressionStmt(
-				new CharLiteral('a', 1),
+				new CharLiteral(new Tok(TokType.CharLiteral, "a", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "'a'");
@@ -506,9 +537,9 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedLogical(
-					new BoolLiteral(true, 1),
+					new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 					new Tok(TokType.And, "and", 1),
-					new BoolLiteral(false, 1),
+					new BoolLiteral(new Tok(TokType.False, "false", 1), 1),
 					new AuraBool(),
 					1),
 				1)
@@ -538,7 +569,7 @@ public class CompilerTest
 							Visibility.Private),
 						1),
 					new Tok(TokType.Identifier, "name", 1),
-					new StringLiteral("Bob", 1),
+					new StringLiteral(new Tok(TokType.StringLiteral, "Bob", 1), 1),
 					new AuraString(),
 					1),
 				1)
@@ -574,7 +605,7 @@ public class CompilerTest
 			new TypedExpressionStmt(
 				new TypedUnary(
 					new Tok(TokType.Bang, "!", 1),
-					new BoolLiteral(true, 1),
+					new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 					new AuraBool(),
 					1),
 				1)
@@ -590,7 +621,7 @@ public class CompilerTest
 			new TypedExpressionStmt(
 				new TypedUnary(
 					new Tok(TokType.Minus, "-", 1),
-					new IntLiteral(5, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 					new AuraInt(),
 					1),
 				1)
@@ -619,6 +650,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedDefer(
+				new Tok(TokType.Defer, "defer", 1),
 				new TypedCall(
 					new TypedVariable(
 						new Tok(TokType.Identifier, "f", 1),
@@ -630,6 +662,7 @@ public class CompilerTest
 								new AuraNil())),
 						1),
 					new List<ITypedAuraExpression>(),
+					new Tok(TokType.RightParen, ")", 1),
 					new AuraNil(),
 					1),
 				1)
@@ -643,11 +676,13 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedFor(
+				new Tok(TokType.For, "for", 1),
 				new TypedLet(
+					new Tok(TokType.Let, "let", 1),
 					new List<Tok>{ new(TokType.Identifier, "i", 1) },
 					false,
 					true,
-					new IntLiteral(0, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "0", 1), 1),
 					1),
 				new TypedLogical(
 					new TypedVariable(
@@ -655,11 +690,12 @@ public class CompilerTest
 						new AuraInt(),
 						1),
 					new Tok(TokType.Less, "<", 1),
-					new IntLiteral(10, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "10", 1), 1),
 					new AuraBool(),
 					1),
 				null,
 				new List<ITypedAuraStatement>(),
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "for i := 0; i < 10; {}");
@@ -671,11 +707,13 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedFor(
+				new Tok(TokType.For, "for", 1),
 				new TypedLet(
+					new Tok(TokType.Let, "let", 1),
 					new List<Tok>{ new(TokType.Identifier, "i", 1) },
 					false,
 					true,
-					new IntLiteral(0, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "0", 1), 1),
 					1),
 				new TypedLogical(
 					new TypedVariable(
@@ -683,19 +721,21 @@ public class CompilerTest
 						new AuraInt(),
 						1),
 					new Tok(TokType.Less, "<", 1),
-					new IntLiteral(10, 1),
+					new IntLiteral(new Tok(TokType.IntLiteral, "10", 1), 1),
 					new AuraBool(),
 					1),
 				null,
 				new List<ITypedAuraStatement>
 				{
 					new TypedLet(
+						null,
 						new List<Tok>{ new(TokType.Identifier, "name", 2) },
 						false,
 						false,
-						new StringLiteral("Bob", 2),
+						new StringLiteral(new Tok(TokType.StringLiteral, "Bob", 1), 2),
 						2)
 				},
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "for i := 0; i < 10; {\nname := \"Bob\"\n}");
@@ -707,12 +747,14 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedForEach(
+				new Tok(TokType.ForEach, "foreach", 1),
 				new Tok(TokType.Identifier, "name", 1),
 				new TypedVariable(
 					new Tok(TokType.Identifier, "names", 1),
 					new AuraList(new AuraString()),
 					1),
 				new List<ITypedAuraStatement>(),
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "for _, name := range names {}");
@@ -724,6 +766,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedForEach(
+				new Tok(TokType.ForEach, "foreach", 1),
 				new Tok(TokType.Identifier, "name", 1),
 				new TypedVariable(
 					new Tok(TokType.Identifier, "names", 1),
@@ -732,12 +775,14 @@ public class CompilerTest
 				new List<ITypedAuraStatement>
 				{
 					new TypedLet(
+						null,
 						new List<Tok>{ new(TokType.Identifier, "i", 1) },
 						true,
 						false,
-						new IntLiteral(5, 1),
+						new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 						2)
 				},
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "for _, name := range names {\nvar i int = 5\n}");
@@ -749,9 +794,10 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedNamedFunction(
+				new Tok(TokType.Fn, "fn", 1),
 				new Tok(TokType.Identifier, "f", 1),
 				new List<Param>(),
-				new TypedBlock(new List<ITypedAuraStatement>(), new AuraNil(), 1),
+				new TypedBlock(new Tok(TokType.LeftBrace, "{", 1), new List<ITypedAuraStatement>(), new Tok(TokType.RightBrace, "}", 1), new AuraNil(), 1),
 				new AuraNil(),
 				Visibility.Private,
 				1)
@@ -766,8 +812,9 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedAnonymousFunction(
+					new Tok(TokType.Fn, "fn", 1),
 					new List<Param>(),
-					new TypedBlock(new List<ITypedAuraStatement>(), new AuraNil(), 1),
+					new TypedBlock(new Tok(TokType.LeftBrace, "{", 1), new List<ITypedAuraStatement>(), new Tok(TokType.RightBrace, "}", 1), new AuraNil(), 1),
 					new AuraNil(),
 					1),
 				1)
@@ -781,10 +828,11 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedLet(
+				null,
 				new List<Tok>{ new(TokType.Identifier, "i", 1) },
 				true,
 				false,
-				new IntLiteral(5, 1),
+				new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "var i int = 5");
@@ -796,10 +844,11 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedLet(
+				null,
 				new List<Tok>{ new(TokType.Identifier, "i", 1) },
 				false,
 				false,
-				new IntLiteral(5, 1),
+				new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1),
 				1)
 		});
 		MakeAssertions(output, "i := 5");
@@ -811,6 +860,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedMod(
+				new Tok(TokType.Mod, "mod", 1),
 				new Tok(TokType.Identifier, "main", 1),
 				1)
 		});
@@ -820,14 +870,14 @@ public class CompilerTest
 	[Test]
 	public void TestCompile_Return_NoValue()
 	{
-		var output = ArrangeAndAct(new List<ITypedAuraStatement> { new TypedReturn(null, 1) });
+		var output = ArrangeAndAct(new List<ITypedAuraStatement> { new TypedReturn(new Tok(TokType.Return, "return", 1), null, 1) });
 		MakeAssertions(output, "return");
 	}
 
 	[Test]
 	public void TestCompile_Return()
 	{
-		var output = ArrangeAndAct(new List<ITypedAuraStatement> { new TypedReturn(new IntLiteral(5, 1), 1) });
+		var output = ArrangeAndAct(new List<ITypedAuraStatement> { new TypedReturn(new Tok(TokType.Return, "return", 1), new IntLiteral(new Tok(TokType.IntLiteral, "5", 1), 1), 1) });
 		MakeAssertions(output, "return 5");
 	}
 
@@ -837,6 +887,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new FullyTypedClass(
+				new Tok(TokType.Class, "class", 1),
 				new Tok(TokType.Identifier, "Greeter", 1),
 				new List<Param>(),
 				new List<TypedNamedFunction>(),
@@ -846,6 +897,7 @@ public class CompilerTest
 					new("IGreeter", new List<AuraNamedFunction>(), Visibility.Private),
 					new("IGreeter2", new List<AuraNamedFunction>(), Visibility.Private)
 				},
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		// Since classes implicitly implement interfaces in Go, the compiler doesn't need any special handling
@@ -859,11 +911,13 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new FullyTypedClass(
+				new Tok(TokType.Class, "class", 1),
 				new Tok(TokType.Identifier, "Greeter", 1),
 				new List<Param>(),
 				new List<TypedNamedFunction>(),
 				Visibility.Public,
 				new List<AuraInterface> { new("IGreeter", new List<AuraNamedFunction>(), Visibility.Private) },
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		// Since classes implicitly implement interfaces in Go, the compiler doesn't need any special handling
@@ -877,11 +931,13 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new FullyTypedClass(
+				new Tok(TokType.Class, "class", 1),
 				new Tok(TokType.Identifier, "Greeter", 1),
 				new List<Param>(),
 				new List<TypedNamedFunction>(),
 				Visibility.Public,
 				new List<AuraInterface>(),
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "type GREETER struct {}");
@@ -893,8 +949,10 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedWhile(
-				new BoolLiteral(true, 1),
+				new Tok(TokType.While, "while", 1),
+				new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 				new List<ITypedAuraStatement>(),
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "for true {}");
@@ -906,6 +964,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedImport(
+				new Tok(TokType.Import, "import", 1),
 				new Tok(TokType.Identifier, "aura/io", 1),
 				null,
 				1)
@@ -952,6 +1011,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedLet(
+				null,
 				new List<Tok>{ new(TokType.Identifier, "b", 1) },
 				false,
 				false,
@@ -977,6 +1037,7 @@ public class CompilerTest
 		{
 			new TypedExpressionStmt(
 				new TypedIf(
+					new Tok(TokType.If, "if", 1),
 					new TypedIs(
 						new TypedVariable(
 							new Tok(TokType.Identifier, "v", 1),
@@ -988,7 +1049,9 @@ public class CompilerTest
 							Visibility.Private),
 						1),
 					new TypedBlock(
+						new Tok(TokType.LeftBrace, "{", 1),
 						new List<ITypedAuraStatement>(),
+						new Tok(TokType.RightBrace, "}", 1),
 						new AuraNil(),
 						1),
 					null,
@@ -1005,9 +1068,11 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedInterface(
+				new Tok(TokType.Interface, "interface", 1),
 				new Tok(TokType.Identifier, "IGreeter", 1),
 				new List<AuraNamedFunction>(),
 				Visibility.Public,
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "type IGREETER interface {}");
@@ -1019,11 +1084,13 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedMultipleImport(
+				Import: new Tok(TokType.Import, "import", 1),
 				Packages: new List<TypedImport>
 				{
-					new(new Tok(TokType.Identifier, "aura/io", 1), null, 1),
-					new(new Tok(TokType.Identifier, "aura/strings", 1), null, 1)
+					new(new Tok(TokType.Import, "import", 1), new Tok(TokType.Identifier, "aura/io", 1), null, 1),
+					new(new Tok(TokType.Import, "import,", 1), new Tok(TokType.Identifier, "aura/strings", 1), null, 1)
 				},
+				ClosingParen: new Tok(TokType.RightParen, ")", 1),
 				Line: 1
 			)
 		});
@@ -1036,6 +1103,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedInterface(
+				new Tok(TokType.Interface, "interface", 1),
 				new Tok(TokType.Identifier, "IGreeter", 1),
 				new List<AuraNamedFunction>
 				{
@@ -1055,6 +1123,7 @@ public class CompilerTest
 							new AuraString()))
 				},
 				Visibility.Public,
+				new Tok(TokType.RightBrace, "}", 1),
 				1)
 		});
 		MakeAssertions(output, "type IGREETER interface {\nSAY_HI(i int) string\n}");
@@ -1066,8 +1135,9 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedYield(
+				Yield: new Tok(TokType.Yield, "yield", 1),
 				Value: new IntLiteral(
-					I: 5,
+					Int: new Tok(TokType.IntLiteral, "5", 1),
 					Line: 1
 				),
 				Line: 1
@@ -1082,6 +1152,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedCheck(
+				Check: new Tok(TokType.Check, "check", 1),
 				Call: new TypedCall(
 					Callee: new TypedVariable(
 						Name: new Tok(
@@ -1101,6 +1172,7 @@ public class CompilerTest
 					),
 					Arguments: new List<ITypedAuraExpression>(),
 					Typ: new AuraError(),
+					ClosingParen: new Tok(TokType.RightParen, ")", 1),
 					Line: 1
 				),
 				Line: 1
@@ -1115,12 +1187,14 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedStruct(
+				Struct: new Tok(TokType.Struct, "struct", 1),
 				Name: new Tok(
 					typ: TokType.Identifier,
 					value: "s",
 					line: 1
 				),
 				Params: new List<Param>(),
+				ClosingParen: new Tok(TokType.RightParen, ")", 1),
 				Line: 1
 			)
 		});
@@ -1133,6 +1207,7 @@ public class CompilerTest
 		var output = ArrangeAndAct(new List<ITypedAuraStatement>
 		{
 			new TypedStruct(
+				Struct: new Tok(TokType.Struct, "struct", 1),
 				Name: new Tok(
 					typ: TokType.Identifier,
 					value: "s",
@@ -1153,6 +1228,7 @@ public class CompilerTest
 						)
 					)
 				},
+				ClosingParen: new Tok(TokType.RightParen, ")", 1),
 				Line: 1
 			)
 		});

--- a/AuraLang.Test/Parser/ParserTest.cs
+++ b/AuraLang.Test/Parser/ParserTest.cs
@@ -13,268 +13,895 @@ public class ParserTest
 	[Test]
 	public void TestParse_Assignment()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "i", 1),
-			new(TokType.Equal, "=", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst,
-			new UntypedExpressionStmt(
-				new UntypedAssignment(
-					new Tok(TokType.Identifier, "i", 1),
-					new IntLiteral(5, 1),
-					1
-				), 1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.Equal,
+					value: "=",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedAssignment(
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "i",
+						line: 1
+					),
+					Value: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Binary()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.IntLiteral, "1", 1),
-			new(TokType.Plus, "+", 1),
-			new(TokType.IntLiteral, "2", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst,
-			new UntypedExpressionStmt(
-				new UntypedBinary(
-					new IntLiteral(1, 1),
-					new Tok(TokType.Plus, "+", 1),
-					new IntLiteral(2, 1),
-					1
-				), 1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.IntLiteral,
+					value: "1",
+					line: 1
+				),
+				new(
+					typ: TokType.Plus,
+					value: "+",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "2",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedBinary(
+					Left: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "1",
+							line: 1
+						),
+						Line: 1
+					),
+					Operator: new Tok(
+						typ: TokType.Plus,
+						value: "+",
+						line: 1
+					),
+					Right: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "2",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Block()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.IntLiteral, "1", 2),
-			new(TokType.Semicolon, ";", 2),
-			new(TokType.RightBrace, "}", 3),
-			new(TokType.Semicolon, ";", 3),
-			new(TokType.Eof, "eof", 3)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedBlock(
-				new List<IUntypedAuraStatement>
-				{
-					new UntypedExpressionStmt(
-						new IntLiteral(1, 2),
-						2)
-				},
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "1",
+					line: 2
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 2
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 3
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 3
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 3
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<IUntypedAuraStatement>
+					{
+						new UntypedExpressionStmt(
+							Expression: new IntLiteral(
+								Int: new Tok(
+									typ: TokType.IntLiteral,
+									value: "1",
+									line: 2
+								),
+								Line: 2
+							),
+							Line: 2
+						)
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 3
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Call()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "f", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedCall(new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-				new List<(Tok?, IUntypedAuraExpression)>(), 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedCall(
+					Callee: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "f",
+							line: 1
+						),
+						Line: 1
+					),
+					Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Get()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "greeter", 1),
-			new(TokType.Dot, ".", 1),
-			new(TokType.Identifier, "name", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1),
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedGet(
-				new UntypedVariable(new Tok(TokType.Identifier, "greeter", 1), 1),
-				new Tok(TokType.Identifier, "name", 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "greeter",
+					line: 1
+				),
+				new(
+					typ: TokType.Dot,
+					value: ".",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "name",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				),
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedGet(
+					Obj: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "greeter",
+							line: 1),
+						Line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "name",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_GetIndex()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "collection", 1),
-			new(TokType.LeftBracket, "[", 1),
-			new(TokType.IntLiteral, "0", 1),
-			new(TokType.RightBracket, "]", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedGetIndex(
-				new UntypedVariable(new Tok(TokType.Identifier, "collection", 1), 1),
-				new IntLiteral(0, 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "collection",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBracket,
+					value: "[",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "0",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBracket,
+					value: "]",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedGetIndex(
+					Obj: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "collection",
+							line: 1
+						),
+						Line: 1
+					),
+					Index: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "0",
+							line: 1
+						),
+						Line: 1
+					),
+					ClosingBracket: new Tok(
+						typ: TokType.RightBracket,
+						value: "]",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_GetIndex_Empty()
 	{
 		ArrangeAndAct_Invalid(
-			new List<Tok>
-			{
-				new(TokType.Identifier, "collection", 1),
-				new(TokType.LeftBracket, "[", 1),
-				new(TokType.RightBracket, "]", 1),
-				new(TokType.Semicolon, ";", 1),
-				new(TokType.Eof, "eof", 1)
-			}, typeof(PostfixIndexCannotBeEmptyException));
+			tokens: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "collection",
+						line: 1
+					),
+					new(
+						typ: TokType.LeftBracket,
+						value: "[",
+						line: 1
+					),
+					new(
+						typ: TokType.RightBracket,
+						value: "]",
+						line: 1
+					),
+					new(
+						typ: TokType.Semicolon,
+						value: ";",
+						line: 1
+					),
+					new(
+						typ: TokType.Eof,
+						value: "eof",
+						line: 1
+					)
+				},
+			expected: typeof(PostfixIndexCannotBeEmptyException)
+		);
 	}
 
 	[Test]
 	public void TestParse_GetIndexRange()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "collection", 1),
-			new(TokType.LeftBracket, "[", 1),
-			new(TokType.IntLiteral, "0", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.IntLiteral, "1", 1),
-			new(TokType.RightBracket, "]", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedGetIndexRange(
-				new UntypedVariable(new Tok(TokType.Identifier, "collection", 1), 1),
-				new IntLiteral(0, 1),
-				new IntLiteral(1, 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "collection",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBracket,
+					value: "[",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "0",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "1",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBracket,
+					value: "]",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedGetIndexRange(
+					Obj: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "collection",
+							line: 1
+						),
+						Line: 1
+					),
+					Lower: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "0",
+							line: 1
+						),
+						Line: 1
+					),
+					Upper: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "1",
+							line: 1
+						),
+						Line: 1
+					),
+					ClosingBracket: new Tok(
+						typ: TokType.RightBracket,
+						value: "]",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Grouping()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.IntLiteral, "1", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedGrouping(
-				new IntLiteral(1, 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "1",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedGrouping(
+					OpeningParen: new Tok(
+						typ: TokType.LeftParen,
+						value: "(",
+						line: 1
+					),
+					Expr: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "1",
+							line: 1
+						),
+						Line: 1
+					),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_If()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.If, "if", 1),
-			new(TokType.True, "true", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.Return, "return", 2),
-			new(TokType.IntLiteral, "1", 2),
-			new(TokType.Semicolon, ";", 2),
-			new(TokType.RightBrace, "}", 3),
-			new(TokType.Semicolon, ";", 3),
-			new(TokType.Eof, "eof", 3)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedIf(
-				new BoolLiteral(true, 1),
-				new UntypedBlock(
-					new List<IUntypedAuraStatement>
-					{
-						new UntypedReturn(
-							new List<IUntypedAuraExpression>{ new IntLiteral(1, 2) },
-							2),
-					},
-					1),
-				null,
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.If,
+					value: "if",
+					line: 1
+				),
+				new(
+					typ: TokType.True,
+					value: "true",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.Return,
+					value: "return",
+					line: 2
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "1",
+					line: 2
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 2
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 3
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 3
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 3
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedIf(
+					If: new Tok(
+						typ: TokType.If,
+						value: "if",
+						line: 1
+					),
+					Condition: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Then: new UntypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<IUntypedAuraStatement>
+						{
+							new UntypedReturn(
+								Return: new Tok(
+									typ: TokType.Return,
+									value: "return",
+									line: 2
+								),
+								Value: new List<IUntypedAuraExpression>
+								{
+									new IntLiteral(
+										Int: new Tok(
+											typ: TokType.IntLiteral,
+											value: "1",
+											line: 2
+										),
+										Line: 2
+									)
+								},
+								Line: 2
+							),
+						},
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 3
+						),
+						Line: 1
+					),
+					Else: null,
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_IntLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.IntLiteral, "5", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new IntLiteral(5, 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_FloatLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.FloatLiteral, "5.0", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new FloatLiteral(5.0, 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.FloatLiteral,
+					value: "5.0",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new FloatLiteral(
+					Float: new Tok(
+						typ: TokType.FloatLiteral,
+						value: "5.0",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_StringLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.StringLiteral, "Hello", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new StringLiteral("Hello", 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.StringLiteral,
+					value: "Hello",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new StringLiteral(
+					String: new Tok(
+						typ: TokType.StringLiteral,
+						value: "Hello",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_ListLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.LeftBracket, "[", 1),
-			new(TokType.Int, "int", 1),
-			new(TokType.RightBracket, "]", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Comma, ",", 1),
-			new(TokType.IntLiteral, "6", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new ListLiteral<ITypedAuraExpression>(
-				new List<ITypedAuraExpression> { new IntLiteral(5, 1), new IntLiteral(6, 1) },
-				new AuraInt(),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.LeftBracket,
+					value: "[",
+					line: 1
+				),
+				new(
+					typ: TokType.Int,
+					value: "int",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBracket,
+					value: "]",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Comma,
+					value: ",",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "6",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new ListLiteral<ITypedAuraExpression>(
+					OpeningBracket: new Tok(
+						typ: TokType.LeftBracket,
+						value: "[",
+						line: 1
+					),
+					L: new List<ITypedAuraExpression>
+					{
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "5",
+								line: 1
+							),
+							Line: 1
+						),
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "6",
+								line: 1
+							),
+							Line: 1
+						)
+					},
+					Kind: new AuraInt(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -282,819 +909,2829 @@ public class ParserTest
 	{
 		var untypedAst = ArrangeAndAct(new List<Tok>
 		{
-			new(TokType.Map, "map", 1),
-			new(TokType.LeftBracket, "[", 1),
-			new(TokType.String, "string", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Int, "int", 1),
-			new(TokType.RightBracket, "]", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.StringLiteral, "Hello", 2),
-			new(TokType.Colon, ":", 2),
-			new(TokType.IntLiteral, "1", 2),
-			new(TokType.Comma, ",", 2),
-			new(TokType.Semicolon, ";", 2),
-			new(TokType.StringLiteral, "World", 3),
-			new(TokType.Colon, ":", 3),
-			new(TokType.IntLiteral, "2", 3),
-			new(TokType.Comma, ",", 3),
-			new(TokType.Semicolon, ";", 3),
-			new(TokType.RightBrace, "}", 4),
-			new(TokType.LeftBracket, "[", 4),
-			new(TokType.StringLiteral, "Hello", 4),
-			new(TokType.RightBracket, "]", 4),
-			new(TokType.Semicolon, ";", 4),
-			new(TokType.Eof, "eof", 4)
+			new(
+				typ: TokType.Map,
+				value: "map",
+				line: 1
+			),
+			new(
+				typ: TokType.LeftBracket,
+				value: "[",
+				line: 1
+			),
+			new(
+				typ: TokType.String,
+				value: "string",
+				line: 1
+			),
+			new(
+				typ: TokType.Colon,
+				value: ":",
+				line: 1
+			),
+			new(
+				typ: TokType.Int,
+				value: "int",
+				line: 1
+			),
+			new(
+				typ: TokType.RightBracket,
+				value: "]",
+				line: 1
+			),
+			new(
+				typ: TokType.LeftBrace,
+				value: "{",
+				line: 1
+			),
+			new(
+				typ: TokType.StringLiteral,
+				value: "Hello",
+				line: 2
+			),
+			new(
+				typ: TokType.Colon,
+				value: ":",
+				line: 2
+			),
+			new(
+				typ: TokType.IntLiteral,
+				value: "1",
+				line: 2
+			),
+			new(
+				typ: TokType.Comma,
+				value: ",",
+				line: 2
+			),
+			new(
+				typ: TokType.Semicolon,
+				value: ";",
+				line: 2
+			),
+			new(
+				typ: TokType.StringLiteral,
+				value: "World",
+				line: 3
+			),
+			new(
+				typ: TokType.Colon,
+				value: ":",
+				line: 3
+			),
+			new(
+				typ: TokType.IntLiteral,
+				value: "2",
+				line: 3
+			),
+			new(
+				typ: TokType.Comma,
+				value: ",",
+				line: 3
+			),
+			new(
+				typ: TokType.Semicolon,
+				value: ";",
+				line: 3
+			),
+			new(
+				typ: TokType.RightBrace,
+				value: "}",
+				line: 4
+			),
+			new(
+				typ: TokType.LeftBracket,
+				value: "[",
+				line: 4
+			),
+			new(
+				typ: TokType.StringLiteral,
+				value: "Hello",
+				line: 4
+			),
+			new(
+				typ: TokType.RightBracket,
+				value: "]",
+				line: 4
+			),
+			new(
+				typ: TokType.Semicolon,
+				value: ";",
+				line: 4
+			),
+			new(
+				typ: TokType.Eof,
+				value: "eof",
+				line: 4
+			)
 		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedGetIndex(new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
-				new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
-				{
-					{ new StringLiteral("Hello", 2), new IntLiteral(1, 2) },
-					{ new StringLiteral("World", 3), new IntLiteral(2, 3) }
-				},
-				new AuraString(),
-				new AuraInt(),
-				1), new StringLiteral("Hello", 4), 1),
-			1));
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedGetIndex(
+					Obj: new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
+						Map: new Tok(
+							typ: TokType.Map,
+							value: "map",
+							line: 1
+						),
+						M: new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
+						{
+							{
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "Hello",
+										line: 2
+									),
+									Line: 2
+								),
+								new IntLiteral(
+									Int: new Tok(
+										typ: TokType.IntLiteral,
+										value: "1",
+										line: 2
+									),
+									Line: 2
+								)
+							},
+							{
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "World",
+										line: 3
+									),
+									Line: 3
+								),
+								new IntLiteral(
+									Int: new Tok(
+										typ: TokType.IntLiteral,
+										value: "2",
+										line: 3
+									),
+									Line: 3
+								)
+							}
+						},
+						KeyType: new AuraString(),
+						ValueType: new AuraInt(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 4
+						),
+						Line: 1
+					),
+					Index: new StringLiteral(
+						String: new Tok(
+							typ: TokType.StringLiteral,
+							value: "Hello",
+							line: 4
+						),
+						Line: 4
+					),
+					ClosingBracket: new Tok(
+						typ: TokType.RightBracket,
+						value: "]",
+						line: 4
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_MapLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Map, "map", 1),
-			new(TokType.LeftBracket, "[", 1),
-			new(TokType.String, "string", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Int, "int", 1),
-			new(TokType.RightBracket, "]", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.StringLiteral, "Hello", 2),
-			new(TokType.Colon, ":", 2),
-			new(TokType.IntLiteral, "1", 2),
-			new(TokType.Comma, ",", 2),
-			new(TokType.Semicolon, ";", 2),
-			new(TokType.StringLiteral, "World", 3),
-			new(TokType.Colon, ":", 3),
-			new(TokType.IntLiteral, "2", 3),
-			new(TokType.Comma, ",", 3),
-			new(TokType.Semicolon, ";", 3),
-			new(TokType.RightBrace, "}", 4),
-			new(TokType.Semicolon, ";", 4),
-			new(TokType.Eof, "eof", 4)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
-				new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
-				{
-					{ new StringLiteral("Hello", 2), new IntLiteral(1, 2) },
-					{ new StringLiteral("World", 3), new IntLiteral(2, 3) }
-				},
-				new AuraString(),
-				new AuraInt(),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Map,
+					value: "map",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBracket,
+					value: "[",
+					line: 1
+				),
+				new(
+					typ: TokType.String,
+					value: "string",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Int,
+					value: "int",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBracket,
+					value: "]",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.StringLiteral,
+					value: "Hello",
+					line: 2
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 2
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "1",
+					line: 2
+				),
+				new(
+					typ: TokType.Comma,
+					value: ",",
+					line: 2
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 2
+				),
+				new(
+					typ: TokType.StringLiteral,
+					value: "World",
+					line: 3
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 3
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "2",
+					line: 3
+				),
+				new(
+					typ: TokType.Comma,
+					value: ",",
+					line: 3
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 3
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 4
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 4
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 4
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
+					Map: new Tok(
+						typ: TokType.Map,
+						value: "map",
+						line: 1
+					),
+					M: new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
+					{
+						{
+							new StringLiteral(
+								String: new Tok(
+									typ: TokType.StringLiteral,
+									value: "Hello",
+									line: 2
+								),
+								Line: 2
+							),
+							new IntLiteral(
+								Int: new Tok(
+									typ: TokType.IntLiteral,
+									value: "1",
+									line: 2
+								),
+								Line: 2
+							)
+						},
+						{
+							new StringLiteral(
+								String: new Tok(
+									typ: TokType.StringLiteral,
+									value: "World",
+									line: 3
+								),
+								Line: 3
+							),
+							new IntLiteral(
+								Int: new Tok(
+									typ: TokType.IntLiteral,
+									value: "2",
+									line: 3
+								),
+								Line: 3
+							)
+						}
+					},
+					KeyType: new AuraString(),
+					ValueType: new AuraInt(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 4
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_BoolLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.True, "true", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1),
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new BoolLiteral(true, 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.True,
+					value: "true",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				),
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new BoolLiteral(
+					Bool: new Tok(
+						typ: TokType.True,
+						value: "true",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Nil()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Nil, "nil", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedNil(1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Nil,
+					value: "nil",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedNil(
+					Nil: new Tok(
+						typ: TokType.Nil,
+						value: "nil",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_CharLiteral()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.CharLiteral, "c", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new CharLiteral('c', 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.CharLiteral,
+					value: "c",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new CharLiteral(
+					Char: new Tok(
+						typ: TokType.CharLiteral,
+						value: "c",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Logical()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.True, "true", 1),
-			new(TokType.Or, "or", 1),
-			new(TokType.False, "false", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedLogical(
-				new BoolLiteral(true, 1),
-				new Tok(TokType.Or, "or", 1),
-				new BoolLiteral(false, 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.True,
+					value: "true",
+					line: 1
+				),
+				new(
+					typ: TokType.Or,
+					value: "or",
+					line: 1
+				),
+				new(
+					typ: TokType.False,
+					value: "false",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedLogical(
+					Left: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Operator: new Tok(
+						typ: TokType.Or,
+						value: "or",
+						line: 1
+					),
+					Right: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.False,
+							value: "false",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Set()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "greeter", 1),
-			new(TokType.Dot, ".", 1),
-			new(TokType.Identifier, "name", 1),
-			new(TokType.Equal, "=", 1),
-			new(TokType.StringLiteral, "Bob", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedSet(
-				new UntypedVariable(new Tok(TokType.Identifier, "greeter", 1), 1),
-				new Tok(TokType.Identifier, "name", 1),
-				new StringLiteral("Bob", 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "greeter",
+					line: 1
+				),
+				new(
+					typ: TokType.Dot,
+					value: ".",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "name",
+					line: 1
+				),
+				new(
+					typ: TokType.Equal,
+					value: "=",
+					line: 1
+				),
+				new(
+					typ: TokType.StringLiteral,
+					value: "Bob",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedSet(
+					Obj: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "greeter",
+							line: 1
+						),
+						Line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "name",
+						line: 1
+					),
+					Value: new StringLiteral(
+						String: new Tok(
+							typ: TokType.StringLiteral,
+							value: "Bob",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_This()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.This, "this", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedThis(new Tok(TokType.This, "this", 1), 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.This,
+					value: "this",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedThis(
+					This: new Tok(
+						typ: TokType.This,
+						value: "this",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Unary_Bang()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Bang, "!", 1),
-			new(TokType.True, "true", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedUnary(
-				new Tok(TokType.Bang, "!", 1),
-				new BoolLiteral(true, 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Bang,
+					value: "!",
+					line: 1
+				),
+				new(
+					typ: TokType.True,
+					value: "true",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedUnary(
+					Operator: new Tok(
+						typ: TokType.Bang,
+						value: "!",
+						line: 1
+					),
+					Right: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Unary_Minus()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Minus, "-", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedUnary(
-				new Tok(TokType.Minus, "-", 1),
-				new IntLiteral(5, 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Minus,
+					value: "-",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedUnary(
+					Operator: new Tok(
+						typ: TokType.Minus,
+						value: "-",
+						line: 1
+					),
+					Right: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Variable()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "variable", 1), new(TokType.Semicolon, ";", 1), new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedVariable(new Tok(TokType.Identifier, "variable", 1), 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "variable",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedVariable(
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "variable",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Defer()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Defer, "defer", 1),
-			new(TokType.Identifier, "f", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedDefer(
-			new UntypedCall(
-				new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-				new List<(Tok?, IUntypedAuraExpression)>(),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Defer,
+					value: "defer",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedDefer(
+				Defer: new Tok(
+					typ: TokType.Defer,
+					value: "defer",
+					line: 1
+				),
+				Call: new UntypedCall(
+					Callee: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "f",
+							line: 1
+						),
+						Line: 1
+					),
+					Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_For()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.For, "for", 1),
-			new(TokType.Identifier, "i", 1),
-			new(TokType.ColonEqual, ":=", 1),
-			new(TokType.IntLiteral, "0", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Identifier, "i", 1),
-			new(TokType.Less, "<", 1),
-			new(TokType.IntLiteral, "10", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Identifier, "i", 1),
-			new(TokType.PlusPlus, "++", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedFor(
-			new UntypedLet(
-				new List<Tok> { new(TokType.Identifier, "i", 1) },
-				new List<AuraType?>(),
-				false,
-				new IntLiteral(0, 1),
-				1),
-			new UntypedBinary(
-				new UntypedVariable(new Tok(TokType.Identifier, "i", 1), 1),
-				new Tok(TokType.Less, "<", 1),
-				new IntLiteral(10, 1),
-				1),
-			new UntypedPlusPlusIncrement(new UntypedVariable(new Tok(TokType.Identifier, "i", 1), 1), 1),
-			new List<IUntypedAuraStatement> { },
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.For,
+					value: "for",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.ColonEqual,
+					value: ":=",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "0",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.Less,
+					value: "<",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "10",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.PlusPlus,
+					value: "++",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedFor(
+				For: new Tok(
+					typ: TokType.For,
+					value: "for",
+					line: 1
+				),
+				Initializer: new UntypedLet(
+					Let: null,
+					Names: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						)
+					},
+					NameTyps: new List<AuraType?>(),
+					Mutable: false,
+					Initializer: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "0",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Condition: new UntypedBinary(
+					Left: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						),
+						Line: 1
+					),
+					Operator: new Tok(
+						typ: TokType.Less,
+						value: "<",
+						line: 1
+					),
+					Right: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "10",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Increment: new UntypedPlusPlusIncrement(
+					Name: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						),
+						Line: 1
+					),
+					PlusPlus: new Tok(
+						typ: TokType.PlusPlus,
+						value: "++",
+						line: 1
+					),
+					Line: 1
+				),
+				Body: new List<IUntypedAuraStatement> { },
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_ForEach()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.ForEach, "foreach", 1),
-			new(TokType.Identifier, "i", 1),
-			new(TokType.In, "in", 1),
-			new(TokType.Identifier, "iter", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedForEach(
-			new Tok(TokType.Identifier, "i", 1),
-			new UntypedVariable(new Tok(TokType.Identifier, "iter", 1), 1),
-			new List<IUntypedAuraStatement>(),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.ForEach,
+					value: "foreach",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.In,
+					value: "in",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "iter",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedForEach(
+				ForEach: new Tok(
+					typ: TokType.ForEach,
+					value: "foreach",
+					line: 1
+				),
+				EachName: new Tok(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				Iterable: new UntypedVariable(
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "iter",
+						line: 1
+					),
+					Line: 1
+				),
+				Body: new List<IUntypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_NamedFunction_ReturnError()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Fn, "fn", 1),
-			new(TokType.Identifier, "f", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Arrow, "->", 1),
-			new(TokType.Error, "error", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedNamedFunction(
-			new Tok(TokType.Identifier, "f", 1),
-			new List<Param>(),
-			new UntypedBlock(new List<IUntypedAuraStatement>(), 1),
-			new List<AuraType> { new AuraError() },
-			Visibility.Private,
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Arrow,
+					value: "->",
+					line: 1
+				),
+				new(
+					typ: TokType.Error,
+					value: "error",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedNamedFunction(
+				Fn: new Tok(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new UntypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<IUntypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				),
+				ReturnType: new List<AuraType> { new AuraError() },
+				Public: Visibility.Private,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_NamedFunction_ParamDefaultValue_Invalid()
 	{
 		ArrangeAndAct_Invalid(
-			new List<Tok>
+			tokens: new List<Tok>
 			{
-				new(TokType.Fn, "fn", 1),
-				new(TokType.Identifier, "f", 1),
-				new(TokType.LeftParen, "(", 1),
-				new(TokType.Identifier, "i", 1),
-				new(TokType.Colon, ":", 1),
-				new(TokType.Int, "int", 1),
-				new(TokType.Equal, "=", 1),
-				new(TokType.Identifier, "var", 1),
-				new(TokType.RightParen, ")", 1),
-				new(TokType.LeftBrace, "{", 1),
-				new(TokType.RightBrace, "}", 1),
-				new(TokType.Semicolon, ";", 1),
-				new(TokType.Eof, "eof", 1)
-			}, typeof(ParameterDefaultValueMustBeALiteralException));
+				new(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Int,
+					value: "int",
+					line: 1
+				),
+				new(
+					typ: TokType.Equal,
+					value: "=",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "var",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			},
+			expected: typeof(ParameterDefaultValueMustBeALiteralException)
+		);
 	}
 
 	[Test]
 	public void TestParse_NamedFunction_NoParams_NoReturnType_NoBody()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Fn, "fn", 1),
-			new(TokType.Identifier, "f", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedNamedFunction(
-			new Tok(TokType.Identifier, "f", 1),
-			new List<Param>(),
-			new UntypedBlock(new List<IUntypedAuraStatement>(), 1),
-			null,
-			Visibility.Private,
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedNamedFunction(
+				Fn: new Tok(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new UntypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<IUntypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				),
+				ReturnType: null,
+				Public: Visibility.Private,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_AnonymousFunction_NoParams_NoReturnType_NoBody()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Fn, "fn", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedAnonymousFunction(
-				new List<Param>(),
-				new UntypedBlock(new List<IUntypedAuraStatement>(), 1),
-				null,
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedAnonymousFunction(
+					Fn: new Tok(
+						typ: TokType.Fn,
+						value: "fn",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new UntypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<IUntypedAuraStatement>(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Line: 1
+					),
+					ReturnType: null,
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Let_Long()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Let, "let", 1),
-			new(TokType.Identifier, "i", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Int, "int", 1),
-			new(TokType.Equal, "=", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedLet(
-			new List<Tok> { new(TokType.Identifier, "i", 1) },
-			new List<AuraType?> { new AuraInt() },
-			false,
-			new IntLiteral(5, 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Let,
+					value: "let",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Int,
+					value: "int",
+					line: 1
+				),
+				new(
+					typ: TokType.Equal,
+					value: "=",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedLet(
+				Let: new Tok(
+					typ: TokType.Let,
+					value: "let",
+					line: 1
+				),
+				Names: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "i",
+						line: 1
+					)
+				},
+				NameTyps: new List<AuraType?> { new AuraInt() },
+				Mutable: false,
+				Initializer: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Let_Short()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Identifier, "i", 1),
-			new(TokType.ColonEqual, ":=", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedLet(
-			new List<Tok> { new(TokType.Identifier, "i", 1) },
-			new List<AuraType?>(),
-			false,
-			new IntLiteral(5, 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 1
+				),
+				new(
+					typ: TokType.ColonEqual,
+					value: ":=",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedLet(
+				Let: null,
+				Names: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "i",
+						line: 1
+					)
+				},
+				NameTyps: new List<AuraType?>(),
+				Mutable: false,
+				Initializer: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Mod()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Mod, "mod", 1),
-			new(TokType.Identifier, "main", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedMod(new Tok(TokType.Identifier, "main", 1), 1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Mod,
+					value: "mod",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "main",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedMod(
+				Mod: new Tok(
+					typ: TokType.Mod,
+					value: "mod",
+					line: 1
+				),
+				Value: new Tok(
+					typ: TokType.Identifier,
+					value: "main",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Return()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Return, "return", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedReturn(
-			new List<IUntypedAuraExpression> { new IntLiteral(5, 1) },
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Return,
+					value: "return",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedReturn(
+				Return: new Tok(
+					typ: TokType.Return,
+					value: "return",
+					line: 1
+				),
+				Value: new List<IUntypedAuraExpression>
+				{
+					new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					)
+				},
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Interface_NoMethods()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Interface, "interface", 1),
-			new(TokType.Identifier, "Greeter", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedInterface(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<AuraNamedFunction>(),
-			Visibility.Private,
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedInterface(
+				Interface: new Tok(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Methods: new List<AuraNamedFunction>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Public: Visibility.Private,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Interface_OneMethod_NoParams_NoReturnType()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Interface, "interface", 1),
-			new(TokType.Identifier, "Greeter", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.Fn, "fn", 2),
-			new(TokType.Identifier, "say_hi", 2),
-			new(TokType.LeftParen, "(", 2),
-			new(TokType.RightParen, ")", 2),
-			new(TokType.Semicolon, ";", 2),
-			new(TokType.RightBrace, "}", 3),
-			new(TokType.Semicolon, ";", 3),
-			new(TokType.Eof, "eof", 3)
-		});
-		MakeAssertions(untypedAst, new UntypedInterface(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<AuraNamedFunction> { new("say_hi", Visibility.Private, new AuraFunction(new List<Param>(), new AuraNil())) },
-			Visibility.Private,
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 2
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "say_hi",
+					line: 2
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 2
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 2
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 2
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 3
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 3
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 3
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedInterface(
+				Interface: new Tok(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Methods: new List<AuraNamedFunction>
+				{
+					new(
+						name: "say_hi",
+						pub: Visibility.Private,
+						f: new AuraFunction(
+							fParams: new List<Param>(),
+							returnType: new AuraNil()
+						)
+					)
+				},
+				Public: Visibility.Private,
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 3
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Interface_OneMethod()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Interface, "interface", 1),
-			new(TokType.Identifier, "Greeter", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.Fn, "fn", 2),
-			new(TokType.Identifier, "say_hi", 2),
-			new(TokType.LeftParen, "(", 2),
-			new(TokType.Identifier, "i", 2),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Int, "int", 1),
-			new(TokType.RightParen, ")", 2),
-			new(TokType.Arrow, "->", 2),
-			new(TokType.String, "string", 2),
-			new(TokType.Semicolon, ";", 2),
-			new(TokType.RightBrace, "}", 3),
-			new(TokType.Semicolon, ";", 3),
-			new(TokType.Eof, "eof", 3)
-		});
-		MakeAssertions(untypedAst, new UntypedInterface(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<AuraNamedFunction>
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
 			{
 				new(
-					"say_hi",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>
-						{
-							new(
-								new Tok(TokType.Identifier, "i", 2),
-								new ParamType(
-									new AuraInt(),
-									false,
-									null))
-						},
-						new AuraString())
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 2
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "say_hi",
+					line: 2
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 2
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "i",
+					line: 2
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Int,
+					value: "int",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 2
+				),
+				new(
+					typ: TokType.Arrow,
+					value: "->",
+					line: 2
+				),
+				new(
+					typ: TokType.String,
+					value: "string",
+					line: 2
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 2
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 3
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 3
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 3
 				)
-			},
-			Visibility.Private,
-			1));
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedInterface(
+				Interface: new Tok(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Methods: new List<AuraNamedFunction>
+				{
+					new(
+						name: "say_hi",
+						pub: Visibility.Private,
+						f: new AuraFunction(
+							fParams: new List<Param>
+							{
+								new(
+									Name: new Tok(
+										typ: TokType.Identifier,
+										value: "i",
+										line: 2
+									),
+									ParamType: new(
+										Typ: new AuraInt(),
+										Variadic: false,
+										DefaultValue: null
+									)
+								)
+							},
+							returnType: new AuraString()
+						)
+					)
+				},
+				Public: Visibility.Private,
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 3
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Class_ImplementingTwoInterfaces()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Class, "class", 1),
-			new(TokType.Identifier, "c", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Identifier, "IClass", 1),
-			new(TokType.Comma, ",", 1),
-			new(TokType.Identifier, "IClass2", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedClass(
-			new Tok(TokType.Identifier, "c", 1),
-			new List<Param>(),
-			new List<IUntypedAuraStatement>(),
-			Visibility.Private,
-			new List<Tok> { new(TokType.Identifier, "IClass", 1), new(TokType.Identifier, "IClass2", 1) },
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "c",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "IClass",
+					line: 1
+				),
+				new(
+					typ: TokType.Comma,
+					value: ",",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "IClass2",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "c",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new List<IUntypedAuraStatement>(),
+				Public: Visibility.Private,
+				Implementing: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "IClass",
+						line: 1
+					),
+					new(
+						typ: TokType.Identifier,
+						value: "IClass2",
+						line: 1
+					)
+				},
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Class_ImplementingOneInterface()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Class, "class", 1),
-			new(TokType.Identifier, "c", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Identifier, "IClass", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedClass(
-			new Tok(TokType.Identifier, "c", 1),
-			new List<Param>(),
-			new List<IUntypedAuraStatement>(),
-			Visibility.Private,
-			new List<Tok> { new(TokType.Identifier, "IClass", 1) },
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "c",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "IClass",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "c",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new List<IUntypedAuraStatement>(),
+				Public: Visibility.Private,
+				Implementing: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "IClass",
+						line: 1
+					)
+				},
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Class_NoParams_NoMethods()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Class, "class", 1),
-			new(TokType.Identifier, "c", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedClass(
-			new Tok(TokType.Identifier, "c", 1),
-			new List<Param>(),
-			new List<IUntypedAuraStatement>(),
-			Visibility.Private,
-			new List<Tok>(),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "c",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "c",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new List<IUntypedAuraStatement>(),
+				Public: Visibility.Private,
+				Implementing: new List<Tok>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_While_EmptyBody()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.While, "while", 1),
-			new(TokType.True, "true", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedWhile(
-			new BoolLiteral(true, 1),
-			new List<IUntypedAuraStatement>(),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.While,
+					value: "while",
+					line: 1
+				),
+				new(
+					typ: TokType.True,
+					value: "true",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedWhile(
+				While: new Tok(
+					typ: TokType.While,
+					value: "while",
+					line: 1
+				),
+				Condition: new BoolLiteral(
+					Bool: new Tok(
+						typ: TokType.True,
+						value: "true",
+						line: 1
+					),
+					Line: 1
+				),
+				Body: new List<IUntypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Import_NoAlias()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Import, "import", 1),
-			new(TokType.Identifier, "external_pkg", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedImport(
-			new Tok(TokType.Identifier, "external_pkg", 1),
-			null,
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Import,
+					value: "import",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "external_pkg",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedImport(
+				Import: new Tok(
+					typ: TokType.Import,
+					value: "import",
+					line: 1
+				),
+				Package: new Tok(
+					typ: TokType.Identifier,
+					value: "external_pkg",
+					line: 1
+				),
+				Alias: null,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Import_Alias()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Import, "import", 1),
-			new(TokType.Identifier, "external_pkg", 1),
-			new(TokType.As, "as", 1),
-			new(TokType.Identifier, "ep", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedImport(
-			new Tok(TokType.Identifier, "external_pkg", 1),
-			new Tok(TokType.Identifier, "ep", 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Import,
+					value: "import",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "external_pkg",
+					line: 1
+				),
+				new(
+					typ: TokType.As,
+					value: "as",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "ep",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedImport(
+				Import: new Tok(
+					typ: TokType.Import,
+					value: "import",
+					line: 1
+				),
+				Package: new Tok(
+					typ: TokType.Identifier,
+					value: "external_pkg",
+					line: 1
+				),
+				Alias: new Tok(
+					typ: TokType.Identifier,
+					value: "ep",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Comment()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Comment, "// this is a comment", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedComment(
-			new Tok(TokType.Comment, "// this is a comment", 1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Comment,
+					value: "// this is a comment",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedComment(
+				Text: new Tok(
+					typ: TokType.Comment,
+					value: "// this is a comment",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Yield()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Yield, "yield", 1),
-			new(TokType.IntLiteral, "5", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedYield(new IntLiteral(5, 1), 1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Yield,
+					value: "yield",
+					line: 1
+				),
+				new(
+					typ: TokType.IntLiteral,
+					value: "5",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedYield(
+				Yield: new Tok(
+					typ: TokType.Yield,
+					value: "yield",
+					line: 1
+				),
+				new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_ClassImplementingInterface()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new(TokType.Class, "class", 1),
-			new(TokType.Identifier, "Greeter", 1),
-			new(TokType.LeftParen, "(", 1),
-			new(TokType.RightParen, ")", 1),
-			new(TokType.Colon, ":", 1),
-			new(TokType.Identifier, "IGreeter", 1),
-			new(TokType.LeftBrace, "{", 1),
-			new(TokType.RightBrace, "}", 1),
-			new(TokType.Semicolon, ";", 1),
-			new(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedClass(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<Param>(),
-			new List<IUntypedAuraStatement>(),
-			Visibility.Private,
-			new List<Tok> { new(TokType.Identifier, "IGreeter", 1) },
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Colon,
+					value: ":",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "IGreeter",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				new(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new List<IUntypedAuraStatement>(),
+				Public: Visibility.Private,
+				Implementing: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "IGreeter",
+						line: 1
+					)
+				},
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Is()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new Tok(TokType.Identifier, "v", 1),
-			new Tok(TokType.Is, "is", 1),
-			new Tok(TokType.Identifier, "IGreeter", 1),
-			new Tok(TokType.Semicolon, ";", 1),
-			new Tok(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedExpressionStmt(
-			new UntypedIs(
-				new UntypedVariable(
-					new Tok(
-						TokType.Identifier,
-						"v",
-						1),
-					1),
-				new Tok(TokType.Identifier, "IGreeter", 1),
-				1),
-			1));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Identifier,
+					value: "v",
+					line: 1
+				),
+				new(
+					typ: TokType.Is,
+					value: "is",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "IGreeter",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedExpressionStmt(
+				Expression: new UntypedIs(
+					Expr: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "v",
+							line: 1
+						),
+						Line: 1
+					),
+					Expected: new Tok(
+						typ: TokType.Identifier,
+						value: "IGreeter",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Check()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new Tok(TokType.Check, "check", 1),
-			new Tok(TokType.Identifier, "f", 1),
-			new Tok(TokType.LeftParen, "(", 1),
-			new Tok(TokType.RightParen, ")", 1),
-			new Tok(TokType.Semicolon, ";", 1),
-			new Tok(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedCheck(
-			Call: new UntypedCall(
-				Callee: new UntypedVariable(
-					Name: new Tok(TokType.Identifier, "f", 1),
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Check,
+					value: "check",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedCheck(
+				Check: new Tok(
+					typ: TokType.Check,
+					value: "check",
+					line: 1
+				),
+				Call: new UntypedCall(
+					Callee: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "f",
+							line: 1
+						),
+						Line: 1
+					),
+					Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
 					Line: 1
 				),
-				Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
 				Line: 1
-			),
-			Line: 1
-		));
+			)
+		);
 	}
 
 	[Test]
 	public void TestParse_Struct()
 	{
-		var untypedAst = ArrangeAndAct(new List<Tok>
-		{
-			new Tok(TokType.Struct, "struct", 1),
-			new Tok(TokType.Identifier, "s", 1),
-			new Tok(TokType.LeftParen, "(", 1),
-			new Tok(TokType.RightParen, ")", 1),
-			new Tok(TokType.Semicolon, ";", 1),
-			new Tok(TokType.Eof, "eof", 1)
-		});
-		MakeAssertions(untypedAst, new UntypedStruct(
-			Name: new Tok(TokType.Identifier, "s", 1),
-			Params: new List<Param>(),
-			Line: 1
-		));
+		var untypedAst = ArrangeAndAct(
+			tokens: new List<Tok>
+			{
+				new(
+					typ: TokType.Struct,
+					value: "struct",
+					line: 1
+				),
+				new(
+					typ: TokType.Identifier,
+					value: "s",
+					line: 1
+				),
+				new(
+					typ: TokType.LeftParen,
+					value: "(",
+					line: 1
+				),
+				new(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				new(
+					typ: TokType.Semicolon,
+					value: ";",
+					line: 1
+				),
+				new(
+					typ: TokType.Eof,
+					value: "eof",
+					line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			untypedAst: untypedAst,
+			expected: new UntypedStruct(
+				Struct: new Tok(
+					typ: TokType.Struct,
+					value: "struct",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "s",
+					line: 1
+				),
+				Params: new List<Param>(),
+				ClosingParen: new Tok(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	private List<IUntypedAuraStatement> ArrangeAndAct(List<Tok> tokens)
 	{
 		// Arrange
-		tokens.Insert(0, new Tok(
-			typ: TokType.Newline,
-			value: "\n",
-			line: 1
-		));
-		tokens.Insert(0, new Tok(
-			typ: TokType.Semicolon,
-			value: ";",
-			line: 1
-		));
-		tokens.Insert(0, new Tok(
-			typ: TokType.Identifier,
-			value: "main",
-			line: 1
-		));
-		tokens.Insert(0, new Tok(
-			typ: TokType.Mod,
-			value: "mod",
-			line: 1
-		));
+		tokens.Insert(
+			index: 0,
+			item: new Tok(
+				typ: TokType.Newline,
+				value: "\n",
+				line: 1
+			)
+		);
+		tokens.Insert(
+			index: 0,
+			item: new Tok(
+				typ: TokType.Semicolon,
+				value: ";",
+				line: 1
+			)
+		);
+		tokens.Insert(
+			index: 0,
+			item: new Tok(
+				typ: TokType.Identifier,
+				value: "main",
+				line: 1
+			)
+		);
+		tokens.Insert(
+			index: 0,
+			item: new Tok(
+				typ: TokType.Mod,
+				value: "mod",
+				line: 1
+			)
+		);
 		var parser = new AuraParser(tokens, "Test");
 		// Act
 		return parser.Parse();
@@ -1121,12 +3758,21 @@ public class ParserTest
 		untypedAst.RemoveAt(0); // Remove newline after `mod` statement
 		Assert.Multiple(() =>
 		{
-			Assert.That(untypedAst, Is.Not.Null);
-			Assert.That(untypedAst, Has.Count.EqualTo(1));
+			Assert.That(
+				actual: untypedAst,
+				expression: Is.Not.Null
+			);
+			Assert.That(
+				actual: untypedAst,
+				expression: Has.Count.EqualTo(1)
+			);
 
 			var expectedJson = JsonConvert.SerializeObject(expected);
 			var actualJson = JsonConvert.SerializeObject(untypedAst[0]);
-			Assert.That(actualJson, Is.EqualTo(expectedJson));
+			Assert.That(
+				actual: actualJson,
+				expression: Is.EqualTo(expectedJson)
+			);
 		});
 	}
 }

--- a/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
+++ b/AuraLang.Test/TypeChecker/TypeCheckerTest.cs
@@ -1,6 +1,7 @@
 ﻿using AuraLang.AST;
 using AuraLang.Cli.LocalFileSystemModuleProvider;
 using AuraLang.Exceptions.TypeChecker;
+using AuraLang.Location;
 using AuraLang.Shared;
 using AuraLang.Stores;
 using AuraLang.Symbol;
@@ -9,6 +10,7 @@ using AuraLang.TypeChecker;
 using AuraLang.Types;
 using Moq;
 using Newtonsoft.Json;
+using Range = AuraLang.Location.Range;
 
 namespace AuraLang.Test.TypeChecker;
 
@@ -39,14 +41,28 @@ public class TypeCheckerTest
 				new UntypedExpressionStmt(
 					new UntypedAssignment(
 						new Tok(TokType.Identifier, "i", 1),
-						new IntLiteral(6, 1),
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "6",
+								line: 1
+							),
+							Line: 1
+						),
 						1),
 					1)
 			});
 		MakeAssertions(typedAst, new TypedExpressionStmt(
 			new TypedAssignment(
 				new Tok(TokType.Identifier, "i", 1),
-				new IntLiteral(6, 1),
+				new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "6",
+						line: 1
+					),
+					Line: 1
+				),
 				new AuraInt(),
 				1),
 			1));
@@ -59,17 +75,17 @@ public class TypeCheckerTest
 		{
 			new UntypedExpressionStmt(
 				new UntypedBinary(
-					new BoolLiteral(true, 1),
+					new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 					new Tok(TokType.And, "and", 1),
-					new BoolLiteral(false, 1),
+					new BoolLiteral(new Tok(TokType.True, "false", 1), 1),
 					1),
 				1)
 		});
 		MakeAssertions(typedAst, new TypedExpressionStmt(
 			new TypedBinary(
-				new BoolLiteral(true, 1),
+				new BoolLiteral(new Tok(TokType.True, "true", 1), 1),
 				new Tok(TokType.And, "and", 1),
-				new BoolLiteral(false, 1),
+				new BoolLiteral(new Tok(TokType.True, "false", 1), 1),
 				new AuraInt(),
 				1),
 			1));
@@ -78,55 +94,139 @@ public class TypeCheckerTest
 	[Test]
 	public void TestTypeCheck_Block_EmptyBody()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedBlock(
-					new List<IUntypedAuraStatement>(),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedBlock(
-				new List<ITypedAuraStatement>(),
-				new AuraNil(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<IUntypedAuraStatement>(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<ITypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Block()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedBlock(
-					new List<IUntypedAuraStatement>
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<IUntypedAuraStatement>
+						{
+							new UntypedLet(
+								Let: new Tok(
+									typ: TokType.Let,
+									value: "let",
+									line: 2
+								),
+								Names: new List<Tok>{ new(typ: TokType.Identifier, value: "i", line: 2) },
+								NameTyps: new List<AuraType?>{ new AuraInt() },
+								Mutable: false,
+								Initializer: new IntLiteral(
+									Int: new Tok(
+										typ: TokType.IntLiteral,
+										value: "5",
+										line: 2
+									),
+									Line: 2
+								),
+								Line: 2
+							)
+						},
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<ITypedAuraStatement>
 					{
-						new UntypedLet(
-							new List<Tok>{ new(TokType.Identifier, "i", 2) },
-							new List<AuraType?>{ new AuraInt() },
-							false,
-							new IntLiteral(5, 2),
-							2)
+						new TypedLet(
+							Let: new Tok(
+								typ: TokType.Let,
+								value: "let",
+								line: 2
+							),
+							Names: new List<Tok>{ new(typ: TokType.Identifier, value: "i", line: 2) },
+							TypeAnnotation: true,
+							Mutable: false,
+							Initializer: new IntLiteral(
+								Int: new Tok(
+									typ: TokType.IntLiteral,
+									value: "5",
+									line: 2
+								),
+								Line: 2
+							),
+							Line: 2
+						)
 					},
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedBlock(
-				new List<ITypedAuraStatement>
-				{
-					new TypedLet(
-						new List<Tok>{ new(TokType.Identifier, "i", 2) },
-						true,
-						false,
-						new IntLiteral(5, 2),
-						2)
-				},
-				new AuraNil(),
-				1),
-			1));
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -134,38 +234,83 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("f", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"f",
-				new AuraNamedFunction(
-					"f",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>(),
-						new AuraNil()
+				Name: "f",
+				Kind: new AuraNamedFunction(
+					name: "f",
+					pub: Visibility.Private,
+					f: new AuraFunction(
+						fParams: new List<Param>(),
+						returnType: new AuraNil()
 					)
 				)
 			)
 		);
 
 		var typedAst = ArrangeAndAct(
-			new List<IUntypedAuraStatement>
+			untypedAst: new List<IUntypedAuraStatement>
 			{
 				new UntypedExpressionStmt(
-					new UntypedCall(
-						new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-						new List<(Tok?, IUntypedAuraExpression)>(),
+					Expression: new UntypedCall(
+						Callee: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Line: 1
+						),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							range: new Range(
+								start: new Position(
+									character: 2,
+									line: 1
+								),
+								end: new Position(
+									character: 3,
+									line: 1
+								)
+							),
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedCall(
+					Callee: new TypedVariable(
+						new Tok(TokType.Identifier, "f", 1),
+						new AuraNamedFunction("f", Visibility.Private, new AuraFunction(new List<Param>(), new AuraNil())),
 						1),
-					1)
-			});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedCall(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "f", 1),
-					new AuraNamedFunction("f", Visibility.Private, new AuraFunction(new List<Param>(), new AuraNil())),
-					1),
-				new List<ITypedAuraExpression>(),
-				new AuraNil(),
-				1),
-			1));
+					Arguments: new List<ITypedAuraExpression>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						range: new Range(
+							start: new Position(
+								character: 2,
+								line: 1
+							),
+							end: new Position(
+								character: 3,
+								line: 1
+							)
+						),
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -173,54 +318,151 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("f", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"f",
-				new AuraNamedFunction(
-					"f",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>
+				Name: "f",
+				Kind: new AuraNamedFunction(
+					name: "f",
+					pub: Visibility.Private,
+					f: new AuraFunction(
+						fParams: new List<Param>
 						{
 							new(
-								new Tok(TokType.Identifier, "i", 1),
-								new ParamType(new AuraInt(), false, null)),
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "i",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraInt(),
+									Variadic: false,
+									DefaultValue: null
+								)
+							),
 							new(
-								new Tok(TokType.Identifier, "s", 1),
-								new ParamType(new AuraString(), false, null))
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraString(),
+									Variadic: false,
+									DefaultValue: null
+								)
+							)
 						},
-						new AuraNil()
+						returnType: new AuraNil()
 					)
 				)
 			)
 		);
 
 		var typedAst = ArrangeAndAct(
-			new List<IUntypedAuraStatement>
+			untypedAst: new List<IUntypedAuraStatement>
 			{
 				new UntypedExpressionStmt(
-					new UntypedCall(
-						new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-						new List<(Tok?, IUntypedAuraExpression)>
+					Expression: new UntypedCall(
+						Callee: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Line: 1
+						),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>
 						{
 							(
-								new Tok(TokType.Identifier, "s", 1),
-								new StringLiteral("Hello world", 1)),
+								new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "Hello world",
+										line: 1
+									),
+									Line: 1
+								)
+							),
 							(
-								new Tok(TokType.Identifier, "i", 1),
-								new IntLiteral(5, 1))
+								new Tok(
+									typ: TokType.Identifier,
+									value: "i",
+									line: 1
+								),
+								new IntLiteral(
+									Int: new Tok(
+										typ: TokType.IntLiteral,
+										value: "5",
+										line: 1
+									),
+									Line: 1
+								)
+							)
 						},
-						1),
-					1)
-			});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedCall(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "f", 1),
-					new AuraNamedFunction("f", Visibility.Private, new AuraFunction(new List<Param>(), new AuraNil())),
-					1),
-				new List<ITypedAuraExpression> { new IntLiteral(5, 1), new StringLiteral("Hello world", 1) },
-				new AuraNil(),
-				1),
-			1));
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedCall(
+					Callee: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "f",
+							line: 1
+						),
+						Typ: new AuraNamedFunction(
+							name: "f",
+							pub: Visibility.Private,
+							f: new AuraFunction(
+								fParams: new List<Param>(),
+								returnType: new AuraNil()
+							)
+						),
+						Line: 1
+					),
+					Arguments: new List<ITypedAuraExpression>
+					{
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "5",
+								line: 1
+							),
+							Line: 1
+						),
+						new StringLiteral(
+							String: new Tok(
+								typ: TokType.StringLiteral,
+								value: "Hello world",
+								line: 1
+							),
+							Line: 1
+						)
+					},
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -228,51 +470,143 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("f", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"f",
-				new AuraNamedFunction(
-					"f",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>
+				Name: "f",
+				Kind: new AuraNamedFunction(
+					name: "f",
+					pub: Visibility.Private,
+					f: new AuraFunction(
+						fParams: new List<Param>
 						{
 							new(
-								new Tok(TokType.Identifier, "i", 1),
-								new ParamType(new AuraInt(), false, new IntLiteral(10, 1))),
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "i",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraInt(),
+									Variadic: false,
+									DefaultValue: new IntLiteral(
+										Int: new Tok(
+											typ: TokType.IntLiteral,
+											value: "10",
+											line: 1
+										),
+										Line: 1
+									)
+								)
+							),
 							new(
-								new Tok(TokType.Identifier, "s", 1),
-								new ParamType(new AuraString(), false, null))
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraString(),
+									Variadic: false,
+									DefaultValue: null
+								)
+							)
 						},
-						new AuraNil()
+						returnType: new AuraNil()
 					)
 				)
 			)
 		);
 
 		var typedAst = ArrangeAndAct(
-			new List<IUntypedAuraStatement>
+			untypedAst: new List<IUntypedAuraStatement>
 			{
 				new UntypedExpressionStmt(
-					new UntypedCall(
-						new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-						new List<(Tok?, IUntypedAuraExpression)>
+					Expression: new UntypedCall(
+						Callee: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Line: 1
+						),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>
 						{
 							(
-								new Tok(TokType.Identifier, "s", 1),
-								new StringLiteral("Hello world", 1))
+								new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "Hello world",
+										line: 1
+									),
+									Line: 1
+								)
+							)
 						},
-						1),
-					1)
-			});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedCall(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "f", 1),
-					new AuraNamedFunction("f", Visibility.Private, new AuraFunction(new List<Param>(), new AuraNil())),
-					1),
-				new List<ITypedAuraExpression> { new IntLiteral(10, 1), new StringLiteral("Hello world", 1) },
-				new AuraNil(),
-				1),
-			1));
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedCall(
+					Callee: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "f",
+							line: 1
+						),
+						Typ: new AuraNamedFunction(
+							name: "f",
+							pub: Visibility.Private,
+							f: new AuraFunction(
+								fParams: new List<Param>(),
+								returnType: new AuraNil()
+							)
+						),
+						Line: 1
+					),
+					Arguments: new List<ITypedAuraExpression>
+					{
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "10",
+								line: 1
+							),
+							Line: 1
+						),
+						new StringLiteral(
+							String: new Tok(
+								typ: TokType.StringLiteral,
+								value: "Hello world",
+								line: 1
+							),
+							Line: 1
+						)
+					},
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -280,39 +614,93 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("f", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"f",
-				new AuraNamedFunction(
-					"f",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>
+				Name: "f",
+				Kind: new AuraNamedFunction(
+					name: "f",
+					pub: Visibility.Private,
+					f: new AuraFunction(
+						fParams: new List<Param>
 						{
 							new(
-								new Tok(TokType.Identifier, "i", 1),
-								new ParamType(new AuraInt(), false, null)),
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "i",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraInt(),
+									Variadic: false,
+									DefaultValue: null
+								)
+							),
 							new(
-								new Tok(TokType.Identifier, "s", 1),
-								new ParamType(new AuraString(), false, new StringLiteral("Hello world", 1)))
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraString(),
+									Variadic: false,
+									DefaultValue: new StringLiteral(
+										String: new Tok(
+											typ: TokType.StringLiteral,
+											value: "Hello world",
+											line: 1
+										),
+										Line: 1
+									)
+								)
+							)
 						},
-						new AuraNil()
+						returnType: new AuraNil()
 					)
 				)
 			));
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedCall(
-					new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-					new List<(Tok?, IUntypedAuraExpression)>
-					{
-						(
-							new Tok(TokType.Identifier, "s", 1),
-							new StringLiteral("Hello world", 1))
-					},
-					1),
-				1)
-		}, typeof(MustSpecifyValueForArgumentWithoutDefaultValueException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedCall(
+						Callee: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Line: 1
+						),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>
+						{
+							(
+								new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "Hello world",
+										line: 1
+									),
+									Line: 1
+								)
+							)
+						},
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(MustSpecifyValueForArgumentWithoutDefaultValueException)
+		);
 	}
 
 	[Test]
@@ -320,43 +708,98 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("f", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"f",
-				new AuraNamedFunction(
-					"f",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>
+				Name: "f",
+				Kind: new AuraNamedFunction(
+					name: "f",
+					pub: Visibility.Private,
+					f: new AuraFunction(
+						fParams: new List<Param>
 						{
 							new(
-								new Tok(TokType.Identifier, "i", 1),
-								new ParamType(new AuraInt(), false, null)),
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "i",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraInt(),
+									Variadic: false,
+									DefaultValue: null
+								)
+							),
 							new(
-								new Tok(TokType.Identifier, "s", 1),
-								new ParamType(new AuraString(), false, null))
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraString(),
+									Variadic: false,
+									DefaultValue: null
+								)
+							)
 						},
-						new AuraNil()
+						returnType: new AuraNil()
 					)
 				)
 			)
 		);
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedCall(
-					new UntypedVariable(new Tok(TokType.Identifier, "f", 1), 1),
-					new List<(Tok?, IUntypedAuraExpression)>
-					{
-						(
-							new Tok(TokType.Identifier, "s", 1),
-							new StringLiteral("Hello world", 1)),
-						(
-							null,
-							new IntLiteral(5, 1))
-					},
-					1),
-				1)
-		}, typeof(CannotMixNamedAndUnnamedArgumentsException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedCall(
+						Callee: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Line: 1
+						),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>
+						{
+							(
+								new Tok(
+									typ: TokType.Identifier,
+									value: "s",
+									line: 1
+								),
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "Hello world",
+										line: 1
+									),
+									Line: 1
+								)
+							),
+							(
+								null,
+								new IntLiteral(
+									Int: new Tok(
+										typ: TokType.IntLiteral,
+										value: "5",
+										line: 1
+									),
+									Line: 1
+								)
+							)
+						},
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(CannotMixNamedAndUnnamedArgumentsException)
+		);
 	}
 
 	[Test]
@@ -364,54 +807,99 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("greeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"greeter",
-				new AuraClass(
-					"Greeter",
-					new List<Param>
+				Name: "greeter",
+				Kind: new AuraClass(
+					name: "Greeter",
+					parameters: new List<Param>
 					{
 						new(
-							new Tok(TokType.Identifier, "name", 1),
-							new ParamType(new AuraString(), false, null)
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "name",
+								line: 1
+							),
+							ParamType: new(
+								Typ: new AuraString(),
+								Variadic: false,
+								DefaultValue: null
+							)
 						)
 					},
-					new List<AuraNamedFunction>(),
-					new List<AuraInterface>(),
-					Visibility.Private
+					methods: new List<AuraNamedFunction>(),
+					implementing: new List<AuraInterface>(),
+					pub: Visibility.Private
 				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedGet(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "greeter", 1),
-						1),
-					new Tok(TokType.Identifier, "name", 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedGet(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "greeter", 1),
-					new AuraClass(
-						"Greeter",
-						new List<Param>
-						{
-							new Param(
-								new Tok(TokType.Identifier, "name", 1),
-								new ParamType(new AuraString(), false, null))
-						},
-						new List<AuraNamedFunction>(),
-						new List<AuraInterface>(),
-						Visibility.Private),
-					1),
-				new Tok(TokType.Identifier, "name", 1),
-				new AuraString(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedGet(
+						Obj: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "greeter",
+								line: 1
+							),
+							Line: 1
+						),
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "name",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedGet(
+					Obj: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "greeter",
+							line: 1
+						),
+						Typ: new AuraClass(
+							name: "Greeter",
+							parameters: new List<Param>
+							{
+								new(
+									Name: new Tok(
+										typ: TokType.Identifier,
+										value: "name",
+										line: 1
+									),
+									ParamType: new(
+										Typ: new AuraString(),
+										Variadic: false,
+										DefaultValue: null
+									)
+								)
+							},
+							methods: new List<AuraNamedFunction>(),
+							implementing: new List<AuraInterface>(),
+							pub: Visibility.Private
+						),
+						Line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "name",
+						line: 1
+					),
+					Typ: new AuraString(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -419,32 +907,75 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("names", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"names",
-				new AuraList(new AuraString())
+				Name: "names",
+				Kind: new AuraList(kind: new AuraString())
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedGetIndex(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "names", 1),
-						1),
-					new IntLiteral(0, 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedGetIndex(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "names", 1),
-					new AuraList(new AuraString()),
-					1),
-				new IntLiteral(0, 1),
-				new AuraString(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedGetIndex(
+						Obj: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "names",
+								line: 1
+							),
+							Line: 1
+						),
+						Index: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "0",
+								line: 1
+							),
+							Line: 1
+						),
+						ClosingBracket: new Tok(
+							typ: TokType.RightBracket,
+							value: "]",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedGetIndex(
+					Obj: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "names",
+							line: 1
+						),
+						Typ: new AuraList(kind: new AuraString()),
+						Line: 1
+					),
+					Index: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "0",
+							line: 1
+						),
+						Line: 1
+					),
+					ClosingBracket: new Tok(
+						typ: TokType.RightBracket,
+						value: "]",
+						line: 1
+					),
+					Typ: new AuraString(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -452,236 +983,674 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("names", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"names",
-				new AuraList(new AuraString())
+				Name: "names",
+				Kind: new AuraList(kind: new AuraString())
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedGetIndexRange(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "names", 1),
-						1),
-					new IntLiteral(0, 1),
-					new IntLiteral(2, 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedGetIndexRange(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "names", 1),
-					new AuraList(new AuraString()),
-					1),
-				new IntLiteral(0, 1),
-				new IntLiteral(2, 1),
-				new AuraList(new AuraString()),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedGetIndexRange(
+						Obj: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "names",
+								line: 1
+							),
+							Line: 1
+						),
+						Lower: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "0",
+								line: 1
+							),
+							Line: 1
+						),
+						Upper: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "2",
+								line: 1
+							),
+							Line: 1
+						),
+						ClosingBracket: new Tok(
+							typ: TokType.RightBracket,
+							value: "]",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedGetIndexRange(
+					Obj: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "names",
+							line: 1
+						),
+						Typ: new AuraList(kind: new AuraString()),
+						Line: 1
+					),
+					Lower: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "0",
+							line: 1
+						),
+						Line: 1
+					),
+					Upper: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "2",
+							line: 1
+						),
+						Line: 1
+					),
+					ClosingBracket: new Tok(
+						typ: TokType.RightBracket,
+						value: "]",
+						line: 1
+					),
+					Typ: new AuraList(new AuraString()),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Grouping()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedGrouping(
-					new StringLiteral("Hello world", 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedGrouping(
-				new StringLiteral("Hello world", 1),
-				new AuraString(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedGrouping(
+						OpeningParen: new Tok(
+							typ: TokType.LeftParen,
+							value: "(",
+							line: 1
+						),
+						Expr: new StringLiteral(
+							String: new Tok(
+								typ: TokType.StringLiteral,
+								value: "Hello world",
+								line: 1
+							),
+							Line: 1
+						),
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new TypedGrouping(
+					OpeningParen: new Tok(
+						typ: TokType.LeftParen,
+						value: "(",
+						line: 1
+					),
+					Expr: new StringLiteral(
+						String: new Tok(
+							typ: TokType.StringLiteral,
+							value: "Hello world",
+							line: 1
+						),
+						Line: 1
+					),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Typ: new AuraString(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_If_EmptyThenBranch()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedIf(
-					new BoolLiteral(true, 1),
-					new UntypedBlock(
-						new List<IUntypedAuraStatement>(),
-						1),
-					null,
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedIf(
-				new BoolLiteral(true, 1),
-				new TypedBlock(
-					new List<ITypedAuraStatement>(),
-					new AuraNil(),
-					1),
-				null,
-				new AuraNil(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedIf(
+						If: new Tok(
+							typ: TokType.If,
+							value: "if",
+							line: 1
+						),
+						Condition: new BoolLiteral(
+							Bool: new Tok(
+								typ: TokType.True,
+								value: "true",
+								line: 1
+							),
+							Line: 1
+						),
+						Then: new UntypedBlock(
+							OpeningBrace: new Tok(
+								typ: TokType.LeftBrace,
+								value: "{",
+								line: 1
+							),
+							Statements: new List<IUntypedAuraStatement>(),
+							ClosingBrace: new Tok(
+								typ: TokType.RightBrace,
+								value: "}",
+								line: 1
+							),
+							Line: 1
+						),
+						Else: null,
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedIf(
+					If: new Tok(
+						typ: TokType.If,
+						value: "if",
+						line: 1
+					),
+					Condition: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Then: new TypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<ITypedAuraStatement>(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Typ: new AuraNil(),
+						Line: 1
+					),
+					Else: null,
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_IntLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new IntLiteral(5, 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new IntLiteral(5, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_FloatLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new FloatLiteral(5.1, 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new FloatLiteral(5.1, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new FloatLiteral(
+						Float: new Tok(
+							typ: TokType.FloatLiteral,
+							value: "5.1",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new FloatLiteral(
+					Float: new Tok(
+						typ: TokType.FloatLiteral,
+						value: "5.1",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_StringLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new StringLiteral("Hello world", 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new StringLiteral("Hello world", 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new StringLiteral(
+						String: new Tok(
+							typ: TokType.StringLiteral,
+							value: "Hello world",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new StringLiteral(
+					String: new Tok(
+						typ: TokType.StringLiteral,
+						value: "Hello world",
+						line: 1
+					),
+					Line: 1
+				),
+				1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_ListLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new ListLiteral<IUntypedAuraExpression>(
-					new List<IUntypedAuraExpression> { new IntLiteral(1, 1) },
-					new AuraInt(),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new ListLiteral<ITypedAuraExpression>(
-				new List<ITypedAuraExpression> { new IntLiteral(1, 1) },
-				new AuraInt(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new ListLiteral<IUntypedAuraExpression>(
+						OpeningBracket: new Tok(
+							typ: TokType.LeftBracket,
+							value: "[",
+							line: 1
+						),
+						L: new List<IUntypedAuraExpression>
+						{
+							new IntLiteral(
+								Int: new Tok(
+									typ: TokType.IntLiteral,
+									value: "1",
+									line: 1
+								),
+								Line: 1
+							)
+						},
+						Kind: new AuraInt(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "]",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new ListLiteral<ITypedAuraExpression>(
+					OpeningBracket: new Tok(
+						typ: TokType.LeftBracket,
+						value: "[",
+						line: 1
+					),
+					L: new List<ITypedAuraExpression>
+					{
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "1",
+								line: 1
+							),
+							Line: 1
+						)
+					},
+					Kind: new AuraInt(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "]",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_MapLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new MapLiteral<IUntypedAuraExpression, IUntypedAuraExpression>(
-					new Dictionary<IUntypedAuraExpression, IUntypedAuraExpression>
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new MapLiteral<IUntypedAuraExpression, IUntypedAuraExpression>(
+						Map: new Tok(
+							typ: TokType.Map,
+							value: "map",
+							line: 1
+						),
+						M: new Dictionary<IUntypedAuraExpression, IUntypedAuraExpression>
+						{
+							{
+								new StringLiteral(
+									String: new Tok(
+										typ: TokType.StringLiteral,
+										value: "Hello",
+										line: 1
+									),
+									Line: 1
+								),
+								new IntLiteral(
+									Int: new Tok(
+										typ: TokType.IntLiteral,
+										value: "1",
+										line: 1
+									),
+									Line: 1
+								)
+							}
+						},
+						KeyType: new AuraString(),
+						ValueType: new AuraInt(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
+					Map: new Tok(
+						typ: TokType.Map,
+						value: "map",
+						line: 1
+					),
+					M: new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
 					{
-						{ new StringLiteral("Hello", 1), new IntLiteral(1, 1) }
+						{
+							new StringLiteral(
+								String: new Tok(
+									typ: TokType.StringLiteral,
+									value: "Hello",
+									line: 1
+								),
+								Line: 1
+							),
+							new IntLiteral(
+								Int: new Tok(
+									typ: TokType.IntLiteral,
+									value: "1",
+									line: 1
+								),
+								Line: 1
+							)
+						}
 					},
-					new AuraString(),
-					new AuraInt(),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
-				new Dictionary<ITypedAuraExpression, ITypedAuraExpression>
-				{
-					{ new StringLiteral("Hello", 1), new IntLiteral(1, 1) }
-				},
-				new AuraString(),
-				new AuraInt(),
-				1),
-			1));
+					KeyType: new AuraString(),
+					ValueType: new AuraInt(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_BoolLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new BoolLiteral(true, 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new BoolLiteral(true, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new BoolLiteral(
+					Bool: new Tok(
+						typ: TokType.True,
+						value: "true",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_NilLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedNil(1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedNil(1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedNil(
+						Nil: new Tok(
+							typ: TokType.Nil,
+							value: "nil",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new TypedNil(
+					Nil: new Tok(
+						typ: TokType.Nil,
+						value: "nil",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_CharLiteral()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new CharLiteral('a', 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new CharLiteral('a', 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new CharLiteral(
+						Char: new Tok(
+							typ: TokType.CharLiteral,
+							value: "a",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				new CharLiteral(
+					Char: new Tok(
+						typ: TokType.CharLiteral,
+						value: "a",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Logical()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedLogical(
-					new IntLiteral(5, 1),
-					new Tok(TokType.Less, "<", 1),
-					new IntLiteral(10, 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedLogical(
-				new IntLiteral(5, 1),
-				new Tok(TokType.Less, "<", 1),
-				new IntLiteral(10, 1),
-				new AuraBool(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedLogical(
+						Left: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "5",
+								line: 1
+							),
+							Line: 1
+						),
+						Operator: new Tok(
+							typ: TokType.Less,
+							value: "<",
+							line: 1
+						),
+						Right: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "10",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedLogical(
+					Left: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Operator: new Tok(
+						typ: TokType.Less,
+						value: "<",
+						line: 1
+					),
+					Right: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "10",
+							line: 1
+						),
+						Line: 1
+					),
+					Typ: new AuraBool(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -689,55 +1658,114 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("greeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"greeter",
-				new AuraClass(
-					"Greeter",
-					new List<Param>
+				Name: "greeter",
+				Kind: new AuraClass(
+					name: "Greeter",
+					parameters: new List<Param>
 					{
-						new Param(
-							new Tok(TokType.Identifier, "name", 1),
-							new ParamType(new AuraString(), false, null))
+						new(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "name",
+								line: 1
+							),
+							ParamType: new(
+								Typ: new AuraString(),
+								Variadic: false,
+								DefaultValue: null
+							)
+						)
 					},
-					new List<AuraNamedFunction>(),
-					new List<AuraInterface>(),
-					Visibility.Private
+					methods: new List<AuraNamedFunction>(),
+					implementing: new List<AuraInterface>(),
+					pub: Visibility.Private
 				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedSet(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "greeter", 1),
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedSet(
+						Obj: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "greeter",
+								line: 1
+							),
+							Line: 1
+						),
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "name",
+							line: 1
+						),
+						Value: new StringLiteral(
+							String: new Tok(
+								typ: TokType.StringLiteral,
+								value: "Bob",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedSet(
+					Obj: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "greeter",
+							line: 1
+						),
+						Typ: new AuraClass(
+							name: "Greeter",
+							parameters: new List<Param>
+							{
+								new(
+									Name: new Tok(
+										typ: TokType.Identifier,
+										value: "name",
+										line: 1
+									),
+									ParamType: new(
+										Typ: new AuraString(),
+										Variadic: false,
+										DefaultValue: null
+									)
+								)
+							},
+							methods: new List<AuraNamedFunction>(),
+							implementing: new List<AuraInterface>(),
+							pub: Visibility.Private
+						),
 						1),
-					new Tok(TokType.Identifier, "name", 1),
-					new StringLiteral("Bob", 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedSet(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "greeter", 1),
-					new AuraClass(
-						"Greeter",
-						new List<Param>
-						{
-							new Param(
-								new Tok(TokType.Identifier, "name", 1),
-								new ParamType(new AuraString(), false, null))
-						},
-						new List<AuraNamedFunction>(),
-						new List<AuraInterface>(),
-						Visibility.Private),
-					1),
-				new Tok(TokType.Identifier, "name", 1),
-				new StringLiteral("Bob", 1),
-				new AuraString(),
-				1),
-			1));
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "name",
+						line: 1
+					),
+					Value: new StringLiteral(
+						String: new Tok(
+							typ: TokType.StringLiteral,
+							value: "Bob",
+							line: 1
+						),
+						Line: 1
+					),
+					Typ: new AuraString(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -745,79 +1773,176 @@ public class TypeCheckerTest
 	{
 		_enclosingClassStore.Setup(ecs => ecs.Peek())
 			.Returns(new PartiallyTypedClass(
-				new Tok(TokType.Identifier, "Greeter", 1),
-				new List<Param>(),
-				new List<AuraNamedFunction>(),
-				Visibility.Public,
-				new AuraClass(
-					"Greeter",
-					new List<Param>(),
-					new List<AuraNamedFunction>(),
-					new List<AuraInterface>(),
-					Visibility.Private),
-				1));
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Methods: new List<AuraNamedFunction>(),
+				Public: Visibility.Public,
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Typ: new AuraClass(
+					name: "Greeter",
+					parameters: new List<Param>(),
+					methods: new List<AuraNamedFunction>(),
+					implementing: new List<AuraInterface>(),
+					pub: Visibility.Private
+				),
+				Line: 1
+			)
+		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedThis(
-					new Tok(TokType.This, "this", 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedThis(
-				new Tok(TokType.This, "this", 1),
-				new AuraClass(
-					"Greeter",
-					new List<Param>(),
-					new List<AuraNamedFunction>(),
-					new List<AuraInterface>(),
-					Visibility.Private),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedThis(
+						This: new Tok(
+							typ: TokType.This,
+							value: "this",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedThis(
+					This: new Tok(
+						typ: TokType.This,
+						value: "this",
+						line: 1
+					),
+					Typ: new AuraClass(
+						name: "Greeter",
+						parameters: new List<Param>(),
+						methods: new List<AuraNamedFunction>(),
+						implementing: new List<AuraInterface>(),
+						pub: Visibility.Private
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Unary_Bang()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedUnary(
-					new Tok(TokType.Bang, "!", 1),
-					new BoolLiteral(true, 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedUnary(
-				new Tok(TokType.Bang, "!", 1),
-				new BoolLiteral(true, 1),
-				new AuraBool(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedUnary(
+						Operator: new Tok(
+							typ: TokType.Bang,
+							value: "!",
+							line: 1
+						),
+						Right: new BoolLiteral(
+							Bool: new Tok(
+								typ: TokType.True,
+								value: "true",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedUnary(
+					Operator: new Tok(
+						typ: TokType.Bang,
+						value: "!",
+						line: 1
+					),
+					Right: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Typ: new AuraBool(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Unary_Minus()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedUnary(
-					new Tok(TokType.Minus, "-", 1),
-					new IntLiteral(5, 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedUnary(
-				new Tok(TokType.Minus, "-", 1),
-				new IntLiteral(5, 1),
-				new AuraInt(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedUnary(
+						Operator: new Tok(
+							typ: TokType.Minus,
+							value: "-",
+							line: 1
+						),
+						Right: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "5",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedUnary(
+					Operator: new Tok(
+						typ: TokType.Minus,
+						value: "-",
+						line: 1
+					),
+					Right: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Typ: new AuraInt(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -825,25 +1950,42 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("name", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"name",
-				new AuraString()
+				Name: "name",
+				Kind: new AuraString()
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedVariable(
-					new Tok(TokType.Identifier, "name", 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedVariable(
-				new Tok(TokType.Identifier, "name", 1),
-				new AuraString(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "name",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedVariable(
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "name",
+						line: 1
+					),
+					Typ: new AuraString(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -851,47 +1993,76 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("f", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"f",
-				new AuraNamedFunction(
-					"f",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>(),
-						new AuraNil()
+				Name: "f",
+				Kind: new AuraNamedFunction(
+					name: "f",
+					pub: Visibility.Private,
+					f: new AuraFunction(
+						fParams: new List<Param>(),
+						returnType: new AuraNil()
 					)
 				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedDefer(
-				new UntypedCall(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "f", 1),
-						1),
-					new List<(Tok?, IUntypedAuraExpression)>(),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedDefer(
-			new TypedCall(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "f", 1),
-					new AuraNamedFunction(
-						"f",
-						Visibility.Private,
-						new AuraFunction(
-							new List<Param>(),
-							new AuraNil()
-						)
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedDefer(
+					Defer: new Tok(
+						typ: TokType.Defer,
+						value: "defer",
+						line: 1
 					),
-					1
+					Call: new UntypedCall(
+						Callee: new UntypedVariable(
+							new Tok(TokType.Identifier, "f", 1),
+							1),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedDefer(
+				Defer: new Tok(
+					typ: TokType.Defer,
+					value: "defer",
+					line: 1
 				),
-				new List<ITypedAuraExpression>(),
-				new AuraNil(),
-				1),
-			1));
+				Call: new TypedCall(
+					Callee: new TypedVariable(
+						new Tok(TokType.Identifier, "f", 1),
+						new AuraNamedFunction(
+							"f",
+							Visibility.Private,
+							new AuraFunction(
+								new List<Param>(),
+								new AuraNil()
+							)
+						),
+						1
+					),
+					Arguments: new List<ITypedAuraExpression>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -899,50 +2070,143 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("i", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"i",
-				new AuraInt()
+				Name: "i",
+				Kind: new AuraInt()
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedFor(
-				new UntypedLet(
-					new List<Tok>{ new(TokType.Identifier, "i", 1) },
-					new List<AuraType?>(),
-					false,
-					new IntLiteral(0, 1),
-					1),
-				new UntypedLogical(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "i", 1),
-						1),
-					new Tok(TokType.Less, "<", 1),
-					new IntLiteral(10, 1),
-					1),
-				null,
-				new List<IUntypedAuraStatement>(),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedFor(
-			new TypedLet(
-				new List<Tok> { new(TokType.Identifier, "i", 1) },
-				false,
-				false,
-				new IntLiteral(0, 1),
-				1),
-			new TypedLogical(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "i", 1),
-					new AuraInt(),
-					1),
-				new Tok(TokType.Less, "<", 1),
-				new IntLiteral(10, 1),
-				new AuraBool(),
-				1),
-			null,
-			new List<ITypedAuraStatement>(),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedFor(
+					For: new Tok(
+						typ: TokType.For,
+						value: "for",
+						line: 1
+					),
+					Initializer: new UntypedLet(
+						Let: null,
+						Names: new List<Tok>
+						{
+							new(
+								typ: TokType.Identifier,
+								value: "i",
+								line: 1
+							)
+						},
+						NameTyps: new List<AuraType?>(),
+						Mutable: false,
+						Initializer: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "0",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Condition: new UntypedLogical(
+						Left: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "i",
+								line: 1
+							),
+							Line: 1
+						),
+						Operator: new Tok(
+							typ: TokType.Less,
+							value: "<",
+							line: 1
+						),
+						Right: new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "10",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Increment: null,
+					Body: new List<IUntypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedFor(
+				For: new Tok(
+					typ: TokType.For,
+					value: "for",
+					line: 1
+				),
+				Initializer: new TypedLet(
+					Let: null,
+					Names: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						)
+					},
+					TypeAnnotation: false,
+					Mutable: false,
+					Initializer: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "0",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				),
+				Condition: new TypedLogical(
+					Left: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						),
+						Typ: new AuraInt(),
+						Line: 1
+					),
+					Operator: new Tok(
+						typ: TokType.Less,
+						value: "<",
+						line: 1
+					),
+					Right: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "10",
+							line: 1
+						),
+						Line: 1
+					),
+					Typ: new AuraBool(),
+					Line: 1
+				),
+				Increment: null,
+				Body: new List<ITypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -950,29 +2214,74 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("names", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"names",
-				new AuraList(new AuraString())
+				Name: "names",
+				Kind: new AuraList(kind: new AuraString())
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedForEach(
-				new Tok(TokType.Identifier, "name", 1),
-				new UntypedVariable(
-					new Tok(TokType.Identifier, "names", 1),
-					1),
-				new List<IUntypedAuraStatement>(),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedForEach(
-			new Tok(TokType.Identifier, "name", 1),
-			new TypedVariable(
-				new Tok(TokType.Identifier, "names", 1),
-				new AuraList(new AuraString()),
-				1),
-			new List<ITypedAuraStatement>(),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedForEach(
+					ForEach: new Tok(
+						typ: TokType.ForEach,
+						value: "foreach",
+						line: 1
+					),
+					EachName: new Tok(
+						typ: TokType.Identifier,
+						value: "name",
+						line: 1
+					),
+					Iterable: new UntypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "names",
+							line: 1
+						),
+						Line: 1
+					),
+					Body: new List<IUntypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedForEach(
+				ForEach: new Tok(
+					typ: TokType.ForEach,
+					value: "foreach",
+					line: 1
+				),
+				EachName: new Tok(
+					typ: TokType.Identifier,
+					value: "name",
+					line: 1
+				),
+				Iterable: new TypedVariable(
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "names",
+						line: 1
+					),
+					Typ: new AuraList(kind: new AuraString()),
+					Line: 1
+				),
+				Body: new List<ITypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -980,8 +2289,8 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("error", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"error",
-				new AuraNamedFunction(
+				Name: "error",
+				Kind: new AuraNamedFunction(
 					name: "error",
 					pub: Visibility.Public,
 					f: new AuraFunction(
@@ -1006,46 +2315,112 @@ public class TypeCheckerTest
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedNamedFunction(
-				Name: new Tok(TokType.Identifier, "f", 1),
-				Params: new List<Param>(),
-				Body: new UntypedBlock(new List<IUntypedAuraStatement>
-				{
-					new UntypedReturn(
-						Value: new List<IUntypedAuraExpression>
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedNamedFunction(
+					Fn: new Tok(
+						typ: TokType.Fn,
+						value: "fn",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "f",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new UntypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<IUntypedAuraStatement>
 						{
-							new UntypedCall(
-								Callee: new UntypedVariable(
-									Name: new Tok(
-										typ: TokType.Identifier,
-										value: "error",
-										line: 1
-									),
-									Line: 1
+							new UntypedReturn(
+								Return: new Tok(
+									typ: TokType.Return,
+									value: "return",
+									line: 1
 								),
-								Arguments: new List<(Tok?, IUntypedAuraExpression)>
+								Value: new List<IUntypedAuraExpression>
 								{
-									(null, new StringLiteral("Helpful error message", 1))
+									new UntypedCall(
+										Callee: new UntypedVariable(
+											Name: new Tok(
+												typ: TokType.Identifier,
+												value: "error",
+												line: 1
+											),
+											Line: 1
+										),
+										Arguments: new List<(Tok?, IUntypedAuraExpression)>
+										{
+											(
+												null,
+												new StringLiteral(
+													String: new Tok(
+														typ: TokType.StringLiteral,
+														value: "Helpful error message",
+														line: 1
+													),
+													Line: 1
+												)
+											)
+										},
+										ClosingParen: new Tok(
+											typ: TokType.RightParen,
+											value: ")",
+											line: 1
+										),
+										Line: 1
+									)
 								},
 								Line: 1
 							)
 						},
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
 						Line: 1
-					)
-				}, 1),
-				ReturnType: new List<AuraType>{ new AuraError() },
-				Public: Visibility.Public,
-				Line: 1)
-		});
-		MakeAssertions(typedAst, new TypedNamedFunction(
-			Name: new Tok(TokType.Identifier, "f", 1),
-			Params: new List<Param>(),
-			Body: new TypedBlock(
-				Statements: new List<ITypedAuraStatement>
-				{
-					new TypedReturn(
+					),
+					ReturnType: new List<AuraType>{ new AuraError() },
+					Public: Visibility.Public,
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedNamedFunction(
+				Fn: new Tok(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new TypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<ITypedAuraStatement>
+					{
+						new TypedReturn(
+							Return: new Tok(
+								typ: TokType.Return,
+								value: "return",
+								line: 1
+							),
 							Value: new TypedCall(
 								Callee: new TypedVariable(
 									Name: new Tok(
@@ -1079,374 +2454,1022 @@ public class TypeCheckerTest
 								),
 								Arguments: new List<ITypedAuraExpression>
 								{
-									new StringLiteral("Helpful error message", 1)
+									new StringLiteral(
+										String: new Tok(
+											typ: TokType.StringLiteral,
+											value: "Helpful error message",
+											line: 1
+										),
+										Line: 1
+									)
 								},
+								ClosingParen: new Tok(
+									typ: TokType.RightParen,
+									value: ")",
+									line: 1
+								),
 								Typ: new AuraError(),
 								Line: 1
 							),
 							Line: 1
 						)
-				},
-				Typ: new AuraError(),
-				Line: 1),
-			ReturnType: new AuraError(),
-			Public: Visibility.Public,
-			Line: 1));
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Typ: new AuraError(),
+					Line: 1
+				),
+				ReturnType: new AuraError(),
+				Public: Visibility.Public,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_NamedFunction_NoParams_NoReturnType_NoBody()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedNamedFunction(
-				new Tok(TokType.Identifier, "f", 1),
-				new List<Param>(),
-				new UntypedBlock(new List<IUntypedAuraStatement>(), 1),
-				null,
-				Visibility.Public,
-				1)
-		});
-		MakeAssertions(typedAst, new TypedNamedFunction(
-			new Tok(TokType.Identifier, "f", 1),
-			new List<Param>(),
-			new TypedBlock(new List<ITypedAuraStatement>(), new AuraNil(), 1),
-			new AuraNil(),
-			Visibility.Public,
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedNamedFunction(
+					Fn: new Tok(
+						typ: TokType.Fn,
+						value: "fn",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "f",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new UntypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<IUntypedAuraStatement>(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Line: 1
+					),
+					ReturnType: null,
+					Public: Visibility.Public,
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedNamedFunction(
+				Fn: new Tok(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "f",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Body: new TypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
+					Statements: new List<ITypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Typ: new AuraNil(),
+					Line: 1
+				),
+				ReturnType: new AuraNil(),
+				Public: Visibility.Public,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_AnonymousFunction_NoParams_NoReturnType_NoBody()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedAnonymousFunction(
-					new List<Param>(),
-					new UntypedBlock(new List<IUntypedAuraStatement>(), 1),
-					null,
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedAnonymousFunction(
-				new List<Param>(),
-				new TypedBlock(
-					new List<ITypedAuraStatement>(),
-					new AuraNil(),
-					1),
-				new AuraNil(),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedAnonymousFunction(
+						Fn: new Tok(
+							typ: TokType.Fn,
+							value: "fn",
+							line: 1
+						),
+						Params: new List<Param>(),
+						Body: new UntypedBlock(
+							OpeningBrace: new Tok(
+								typ: TokType.LeftBrace,
+								value: "{",
+								line: 1
+							),
+							Statements: new List<IUntypedAuraStatement>(),
+							ClosingBrace: new Tok(
+								typ: TokType.RightBrace,
+								value: "}",
+								line: 1
+							),
+							Line: 1
+						),
+						ReturnType: null,
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedAnonymousFunction(
+					Fn: new Tok(
+						typ: TokType.Fn,
+						value: "fn",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new TypedBlock(
+						OpeningBrace: new Tok(
+							typ: TokType.LeftBrace,
+							value: "{",
+							line: 1
+						),
+						Statements: new List<ITypedAuraStatement>(),
+						ClosingBrace: new Tok(
+							typ: TokType.RightBrace,
+							value: "}",
+							line: 1
+						),
+						Typ: new AuraNil(),
+						Line: 1
+					),
+					ReturnType: new AuraNil(),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Let_Long()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedLet(
-				new List<Tok>{ new(TokType.Identifier, "i", 1) },
-				new List<AuraType?>{ new AuraInt() },
-				false,
-				new IntLiteral(1, 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedLet(
-			new List<Tok> { new(TokType.Identifier, "i", 1) },
-			true,
-			false,
-			new IntLiteral(1, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedLet(
+					Let: new Tok(
+						typ: TokType.Let,
+						value: "let",
+						line: 1
+					),
+					Names: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						)
+					},
+					NameTyps: new List<AuraType?>{ new AuraInt() },
+					Mutable: false,
+					Initializer: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "1",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedLet(
+				Let: new Tok(
+					typ: TokType.Let,
+					value: "let",
+					line: 1
+				),
+				Names: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "i",
+						line: 1
+					)
+				},
+				TypeAnnotation: true,
+				Mutable: false,
+				Initializer: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "1",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Let_Uninitialized()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedLet(
-				new List<Tok>{ new(TokType.Identifier, "i", 1) },
-				new List<AuraType?>{ new AuraInt() },
-				false,
-				null,
-				1)
-		});
-		MakeAssertions(typedAst, new TypedLet(
-			new List<Tok> { new(TokType.Identifier, "i", 1) },
-			true,
-			false,
-			new IntLiteral(0, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedLet(
+					Let: new Tok(
+						typ: TokType.Let,
+						value: "let",
+						line: 1
+					),
+					Names: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						)
+					},
+					NameTyps: new List<AuraType?>{ new AuraInt() },
+					Mutable: false,
+					Initializer: null,
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedLet(
+				Let: new Tok(
+					typ: TokType.Let,
+					value: "let",
+					line: 1
+				),
+				Names: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "i",
+						line: 1
+					)
+				},
+				TypeAnnotation: true,
+				Mutable: false,
+				Initializer: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "0",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Let_Uninitialized_NonDefaultable()
 	{
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement>
-		{
-			new UntypedLet(
-				new List<Tok>{ new(TokType.Identifier, "c", 1) },
-				new List<AuraType?>{ new AuraChar() },
-				false,
-				null,
-				1)
-		}, typeof(MustSpecifyInitialValueForNonDefaultableTypeException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedLet(
+					Let: new Tok(
+						typ: TokType.Let,
+						value: "let",
+						line: 1
+					),
+					Names: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "c",
+							line: 1
+						)
+					},
+					NameTyps: new List<AuraType?>{ new AuraChar() },
+					Mutable: false,
+					Initializer: null,
+					Line: 1
+				)
+			},
+			expected: typeof(MustSpecifyInitialValueForNonDefaultableTypeException));
 	}
 
 	[Test]
 	public void TestTypeCheck_Long_Short()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedLet(
-				new List<Tok>{ new(TokType.Identifier, "i", 1) },
-				new List<AuraType?>(),
-				false,
-				new IntLiteral(1, 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedLet(
-			new List<Tok> { new(TokType.Identifier, "i", 1) },
-			false,
-			false,
-			new IntLiteral(1, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedLet(
+					Let: null,
+					Names: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "i",
+							line: 1
+						)
+					},
+					NameTyps: new List<AuraType?>(),
+					Mutable: false,
+					Initializer: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "1",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedLet(
+				Let: null,
+				Names: new List<Tok>
+				{
+					new(
+						typ: TokType.Identifier,
+						value: "i",
+						line: 1
+					)
+				},
+				TypeAnnotation: false,
+				Mutable: false,
+				Initializer: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "1",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Return_NoValue()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedReturn(
-				null,
-				1)
-		});
-		MakeAssertions(typedAst, new TypedReturn(
-			null,
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedReturn(
+					Return: new Tok(
+						typ: TokType.Return,
+						value: "return",
+						line: 1
+					),
+					Value: null,
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedReturn(
+				Return: new Tok(
+					typ: TokType.Return,
+					value: "return",
+					line: 1
+				),
+				Value: null,
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Return()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedReturn(
-				new List<IUntypedAuraExpression>{ new IntLiteral(5, 1) },
-				1)
-		});
-		MakeAssertions(typedAst, new TypedReturn(
-			new IntLiteral(5, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedReturn(
+					Return: new Tok(
+						typ: TokType.Return,
+						value: "return",
+						line: 1
+					),
+					Value: new List<IUntypedAuraExpression>
+					{
+						new IntLiteral(
+							Int: new Tok(
+								typ: TokType.IntLiteral,
+								value: "5",
+								line: 1
+							),
+							Line: 1
+						)
+					},
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedReturn(
+				Return: new Tok(
+					typ: TokType.Return,
+					value: "return",
+					line: 1
+				),
+				Value: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Class_NoParams_NoMethods()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedClass(
-				new Tok(TokType.Identifier, "Greeter", 1),
-				new List<Param>(),
-				new List<IUntypedAuraStatement>(),
-				Visibility.Private,
-				new List<Tok>(),
-				1)
-		});
-		MakeAssertions(typedAst, new FullyTypedClass(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<Param>(),
-			new List<TypedNamedFunction>(),
-			Visibility.Private,
-			new List<AuraInterface>(),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedClass(
+					Class: new Tok(
+						typ: TokType.Class,
+						value: "class",
+						line: 1
+					),
+					Name: new Tok(TokType.Identifier, "Greeter", 1),
+					Params: new List<Param>(),
+					Body: new List<IUntypedAuraStatement>(),
+					Public: Visibility.Private,
+					Implementing: new List<Tok>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new FullyTypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(TokType.Identifier, "Greeter", 1),
+				Params: new List<Param>(),
+				Methods: new List<TypedNamedFunction>(),
+				Public: Visibility.Private,
+				Implementing: new List<AuraInterface>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_While_EmptyBody()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedWhile(
-				new BoolLiteral(true, 1),
-				new List<IUntypedAuraStatement>(),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedWhile(
-			new BoolLiteral(true, 1),
-			new List<ITypedAuraStatement>(),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedWhile(
+					While: new Tok(
+						typ: TokType.While,
+						value: "while",
+						line: 1
+					),
+					Condition: new BoolLiteral(
+						Bool: new Tok(
+							typ: TokType.True,
+							value: "true",
+							line: 1
+						),
+						Line: 1
+					),
+					Body: new List<IUntypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedWhile(
+				While: new Tok(
+					typ: TokType.While,
+					value: "while",
+					line: 1
+				),
+				Condition: new BoolLiteral(
+					Bool: new Tok(
+						typ: TokType.True,
+						value: "true",
+						line: 1
+					),
+					Line: 1
+				),
+				Body: new List<ITypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
-
-	// [Test]
-	// public void TestTypeCheck_Import_NoAlias()
-	// {
-	// 	_localModuleReader.Setup(m => m.GetModuleSourcePaths(It.IsAny<string>())).Returns(new string[] { "test_pkg" });
-	// 	_localModuleReader.Setup(m => m.Read(It.IsAny<string>())).Returns(string.Empty);
-
-	// 	var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-	// 	{
-	// 		new UntypedImport(
-	// 			new Tok(TokType.Identifier, "test_pkg", 1),
-	// 			null,
-	// 			1)
-	// 	});
-	// 	MakeAssertions(typedAst, new TypedImport(
-	// 		new Tok(TokType.Identifier, "test_pkg", 1),
-	// 		null,
-	// 		1));
-	// }
 
 	[Test]
 	public void TestTypeCheck_Comment()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedComment(
-				new Tok(TokType.Comment, "// this is a comment", 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedComment(
-			new Tok(TokType.Comment, "// this is a comment", 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedComment(
+					Text: new Tok(
+						typ: TokType.Comment,
+						value: "// this is a comment",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedComment(
+				Text: new Tok(
+					typ: TokType.Comment,
+					value: "// this is a comment",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Yield()
 	{
-		_enclosingExprStore.Setup(expr => expr.Peek()).Returns(new UntypedBlock(new List<IUntypedAuraStatement>(), 1));
+		_enclosingExprStore.Setup(expr => expr.Peek()).Returns(
+			new UntypedBlock(
+				OpeningBrace: new Tok(
+					typ: TokType.LeftBrace,
+					value: "{",
+					line: 1
+				),
+				Statements: new List<IUntypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedYield(
-				new IntLiteral(5, 1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedYield(
-			new IntLiteral(5, 1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedYield(
+					Yield: new Tok(
+						typ: TokType.Yield,
+						value: "yield",
+						line: 1
+					),
+					Value: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedYield(
+				Yield: new Tok(
+					typ: TokType.Yield,
+					value: "yield",
+					line: 1
+				),
+				Value: new IntLiteral(
+					Int: new Tok(
+						typ: TokType.IntLiteral,
+						value: "5",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Yield_Invalid()
 	{
-		_enclosingExprStore.Setup(expr => expr.Peek()).Returns(new UntypedNil(1));
+		_enclosingExprStore.Setup(expr => expr.Peek()).Returns(
+			new UntypedNil(
+				Nil: new Tok(
+					typ: TokType.Nil,
+					value: "nil",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement> { new UntypedYield(new IntLiteral(5, 1), 1) },
-			typeof(InvalidUseOfYieldKeywordException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedYield(
+					Yield: new Tok(
+						typ: TokType.Yield,
+						value: "yield",
+						line: 1
+					),
+					Value: new IntLiteral(
+						Int: new Tok(
+							typ: TokType.IntLiteral,
+							value: "5",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(InvalidUseOfYieldKeywordException)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Break()
 	{
-		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(new UntypedWhile(
-			new BoolLiteral(true, 1),
-			new List<IUntypedAuraStatement>(),
-			1));
+		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(
+			new UntypedWhile(
+				While: new Tok(
+					typ: TokType.While,
+					value: "while",
+					line: 1
+				),
+				Condition: new BoolLiteral(
+					Bool: new Tok(
+						typ: TokType.True,
+						value: "true",
+						line: 1
+					),
+					Line: 1
+				),
+				Body: new List<IUntypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement> { new UntypedBreak(1) });
-		MakeAssertions(typedAst, new TypedBreak(1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedBreak(
+					Break: new Tok(
+						typ: TokType.Break,
+						value: "break",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedBreak(
+				Break: new Tok(
+					typ: TokType.Break,
+					value: "break",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Break_Invalid()
 	{
-		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(new UntypedExpressionStmt(new UntypedNil(1), 1));
+		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(
+			new UntypedExpressionStmt(
+				Expression: new UntypedNil(
+					Nil: new Tok(
+						typ: TokType.Nil,
+						value: "nil",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement> { new UntypedBreak(1) },
-			typeof(InvalidUseOfBreakKeywordException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedBreak(
+					Break: new Tok(
+						typ: TokType.Break,
+						value: "break",
+						line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(InvalidUseOfBreakKeywordException)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Continue()
 	{
-		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(new UntypedWhile(
-			new BoolLiteral(true, 1),
-			new List<IUntypedAuraStatement>(),
-			1));
+		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(
+			new UntypedWhile(
+				While: new Tok(
+					typ: TokType.While,
+					value: "while",
+					line: 1
+				),
+				Condition: new BoolLiteral(
+					Bool: new Tok(
+						typ: TokType.True,
+						value: "true",
+						line: 1
+					),
+					Line: 1
+				),
+				Body: new List<IUntypedAuraStatement>(),
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement> { new UntypedContinue(1) });
-		MakeAssertions(typedAst, new TypedContinue(1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedContinue(
+					Continue: new Tok(
+						typ: TokType.Continue,
+						value: "continue",
+						line: 1
+					),
+					Line: 1
+				)
+			});
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedContinue(
+				Continue: new Tok(
+					typ: TokType.Continue,
+					value: "continue",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Continue_Invalid()
 	{
-		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(new UntypedExpressionStmt(new UntypedNil(1), 1));
+		_enclosingStmtStore.Setup(stmt => stmt.Peek()).Returns(
+			new UntypedExpressionStmt(
+				Expression: new UntypedNil(
+					Nil: new Tok(
+						typ: TokType.Nil,
+						value: "nil",
+						line: 1
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement> { new UntypedContinue(1) },
-			typeof(InvalidUseOfContinueKeywordException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedContinue(
+					Continue: new Tok(
+						typ: TokType.Continue,
+						value: "continue",
+						line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(InvalidUseOfContinueKeywordException)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Interface_NoMethods()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedInterface(
-				new Tok(TokType.Identifier, "IGreeter", 1),
-				new List<AuraNamedFunction>(),
-				Visibility.Public,
-				1)
-		});
-		MakeAssertions(typedAst, new TypedInterface(
-			new Tok(TokType.Identifier, "IGreeter", 1),
-			new List<AuraNamedFunction>(),
-			Visibility.Public,
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedInterface(
+					Interface: new Tok(
+						typ: TokType.Interface,
+						value: "interface",
+						line: 1
+					),
+					Name: new Tok(TokType.Identifier, "IGreeter", 1),
+					Methods: new List<AuraNamedFunction>(),
+					Public: Visibility.Public,
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedInterface(
+				Interface: new Tok(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "IGreeter",
+					line: 1
+				),
+				Methods: new List<AuraNamedFunction>(),
+				Public: Visibility.Public,
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Interface_OneMethod()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedInterface(
-				new Tok(TokType.Identifier, "IGreeter", 1),
-				new List<AuraNamedFunction>
-				{
-					new AuraNamedFunction(
-						"say_hi",
-						Visibility.Private,
-						new AuraFunction(
-							new List<Param>
-							{
-								new Param(
-									new Tok(TokType.Identifier, "i", 1),
-									new ParamType(
-										new AuraInt(),
-										false,
-										null))
-							},
-							new AuraString()))
-				},
-				Visibility.Public,
-				1)
-		});
-		MakeAssertions(typedAst, new TypedInterface(
-			new Tok(TokType.Identifier, "IGreeter", 1),
-			new List<AuraNamedFunction>
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
 			{
-				new AuraNamedFunction(
-					"say_hi",
-					Visibility.Private,
-					new AuraFunction(
-						new List<Param>
-						{
-							new Param(
-								new Tok(TokType.Identifier, "i", 1),
-								new ParamType(
-									new AuraInt(),
-									false,
-									null))
-						},
-						new AuraString()))
-			},
-			Visibility.Public,
-			1));
+				new UntypedInterface(
+					Interface: new Tok(
+						typ: TokType.Interface,
+						value: "interface",
+						line: 1
+					),
+					Name: new Tok(TokType.Identifier, "IGreeter", 1),
+					Methods: new List<AuraNamedFunction>
+					{
+						new(
+							name: "say_hi",
+							pub: Visibility.Private,
+							f: new AuraFunction(
+								fParams: new List<Param>
+								{
+									new(
+										Name: new Tok(
+											typ: TokType.Identifier,
+											value: "i",
+											line: 1
+										),
+										ParamType: new(
+											Typ: new AuraInt(),
+											Variadic: false,
+											DefaultValue: null
+										)
+									)
+								},
+								returnType: new AuraString()
+							)
+						)
+					},
+					Public: Visibility.Public,
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedInterface(
+				Interface: new Tok(
+					typ: TokType.Interface,
+					value: "interface",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "IGreeter",
+					line: 1
+				),
+				Methods: new List<AuraNamedFunction>
+				{
+					new(
+						name: "say_hi",
+						pub: Visibility.Private,
+						f: new AuraFunction(
+							fParams: new List<Param>
+							{
+								new(
+									Name: new Tok(
+										typ: TokType.Identifier,
+										value: "i",
+										line: 1
+									),
+									ParamType: new(
+										Typ: new AuraInt(),
+										Variadic: false,
+										DefaultValue: null
+									)
+								)
+							},
+							returnType: new AuraString()
+						)
+					)
+				},
+				Public: Visibility.Public,
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -1454,38 +3477,97 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("IGreeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"IGreeter",
-				new AuraInterface("IGreeter", new List<AuraNamedFunction>(), Visibility.Private)
+				Name: "IGreeter",
+				Kind: new AuraInterface(
+					name: "IGreeter",
+					functions: new List<AuraNamedFunction>(),
+					pub: Visibility.Private
+				)
 			)
 		);
 		_symbolsTable.Setup(v => v.GetSymbol("IGreeter2", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"IGreeter2",
-				new AuraInterface("IGreeter2", new List<AuraNamedFunction>(), Visibility.Private)
+				Name: "IGreeter2",
+				Kind: new AuraInterface(
+					name: "IGreeter2",
+					functions: new List<AuraNamedFunction>(),
+					pub: Visibility.Private
+				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedClass(
-				new Tok(TokType.Identifier, "Greeter", 1),
-				new List<Param>(),
-				new List<IUntypedAuraStatement>(),
-				Visibility.Private,
-				new List<Tok> { new(TokType.Identifier, "IGreeter", 1), new(TokType.Identifier, "IGreeter2", 1) },
-				1)
-		});
-		MakeAssertions(typedAst, new FullyTypedClass(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<Param>(),
-			new List<TypedNamedFunction>(),
-			Visibility.Private,
-			new List<AuraInterface>
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
 			{
-				new("IGreeter", new List<AuraNamedFunction>(), Visibility.Private),
-				new("IGreeter2", new List<AuraNamedFunction>(), Visibility.Private)
-			},
-			1));
+				new UntypedClass(
+					Class: new Tok(
+						typ: TokType.Class,
+						value: "class",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "Greeter",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new List<IUntypedAuraStatement>(),
+					Public: Visibility.Private,
+					Implementing: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "IGreeter",
+							line: 1
+						),
+						new(
+							typ: TokType.Identifier,
+							value: "IGreeter2",
+							line: 1
+						)
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new FullyTypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(TokType.Identifier, "Greeter", 1),
+				Params: new List<Param>(),
+				Methods: new List<TypedNamedFunction>(),
+				Public: Visibility.Private,
+				Implementing: new List<AuraInterface>
+				{
+					new(
+						name: "IGreeter",
+						functions: new List<AuraNamedFunction>(),
+						pub: Visibility.Private
+					),
+					new(
+						name: "IGreeter2",
+						functions: new List<AuraNamedFunction>(),
+						pub: Visibility.Private
+					)
+				},
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -1493,44 +3575,74 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("IGreeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"IGreeter",
-				new AuraInterface("IGreeter",
-				new List<AuraNamedFunction>
-				{
-					new(
-						"f",
-						Visibility.Public,
-						new AuraFunction(
-							new List<Param>
-							{
-								new(
-									new Tok(TokType.Identifier, "i", 1),
-									new ParamType(
-										new AuraInt(),
-										false,
-										null
+				Name: "IGreeter",
+				Kind: new AuraInterface(
+					name: "IGreeter",
+					functions: new List<AuraNamedFunction>
+					{
+						new(
+							name: "f",
+							pub: Visibility.Public,
+							f: new AuraFunction(
+								fParams: new List<Param>
+								{
+									new(
+										Name: new Tok(
+											typ: TokType.Identifier,
+											value: "i",
+											line: 1
+										),
+										ParamType: new(
+											Typ: new AuraInt(),
+											Variadic: false,
+											DefaultValue: null
+										)
 									)
-								)
-							},
-							new AuraInt()
+								},
+								returnType: new AuraInt()
+							)
 						)
-					)
-				},
-				Visibility.Private)
+					},
+					pub: Visibility.Private
+				)
 			)
 		);
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement>
-		{
-			new UntypedClass(
-				Name: new Tok(TokType.Identifier, "Greeter", 1),
-				Params: new List<Param>(),
-				Body: new List<IUntypedAuraStatement>{},
-				Public: Visibility.Private,
-				Implementing: new List<Tok> { new(TokType.Identifier, "IGreeter", 1) },
-				Line: 1)
-		},
-		typeof(MissingInterfaceMethodException));
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedClass(
+					Class: new Tok(
+						typ: TokType.Class,
+						value: "class",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "Greeter",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new List<IUntypedAuraStatement>{},
+					Public: Visibility.Private,
+					Implementing: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "IGreeter",
+							line: 1
+						)
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(MissingInterfaceMethodException)
+		);
 	}
 
 	[Test]
@@ -1538,73 +3650,141 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("IGreeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"IGreeter",
-				new AuraInterface("IGreeter",
-				new List<AuraNamedFunction>
-				{
-					new(
-						"f",
-						Visibility.Public,
-						new AuraFunction(
-							new List<Param>
-							{
-								new(
-									new Tok(TokType.Identifier, "i", 1),
-									new ParamType(
-										new AuraInt(),
-										false,
-										null
+				Name: "IGreeter",
+				Kind: new AuraInterface(
+					name: "IGreeter",
+					functions: new List<AuraNamedFunction>
+					{
+						new(
+							name: "f",
+							pub: Visibility.Public,
+							f: new AuraFunction(
+								fParams: new List<Param>
+								{
+									new(
+										new Tok(
+											typ: TokType.Identifier,
+											value: "i",
+											line: 1
+										),
+										new ParamType(
+											Typ: new AuraInt(),
+											Variadic: false,
+											DefaultValue: null
+										)
 									)
-								)
-							},
-							new AuraInt()
+								},
+								returnType: new AuraInt()
+							)
 						)
-					)
-				},
-				Visibility.Private)
+					},
+					pub: Visibility.Private
+				)
 			)
 		);
 
-		ArrangeAndAct_Invalid(new List<IUntypedAuraStatement>
-		{
-			new UntypedClass(
-				Name: new Tok(TokType.Identifier, "Greeter", 1),
-				Params: new List<Param>(),
-				Body: new List<IUntypedAuraStatement>
-				{
-					new UntypedNamedFunction(
-						Name: new Tok(TokType.Identifier, "f", 1),
-						Params: new List<Param>
-						{
-							new(
-								Name: new Tok(TokType.Identifier, "i", 1),
-								ParamType: new ParamType(
-									new AuraInt(),
-									false,
-									null
-								)
-							)
-						},
-						Body: new UntypedBlock(
-							Statements: new List<IUntypedAuraStatement>
+		ArrangeAndAct_Invalid(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedClass(
+					Class: new Tok(
+						typ: TokType.Class,
+						value: "class",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "Greeter",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new List<IUntypedAuraStatement>
+					{
+						new UntypedNamedFunction(
+							Fn: new Tok(
+								typ: TokType.Fn,
+								value: "fn",
+								line: 1
+							),
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Params: new List<Param>
 							{
-								new UntypedReturn(
-									Value: new List<IUntypedAuraExpression>{ new IntLiteral(I: 5, Line: 1) },
-									Line: 1
+								new(
+									Name: new Tok(
+										typ: TokType.Identifier,
+										value: "i",
+										line: 1
+									),
+									ParamType: new ParamType(
+										Typ: new AuraInt(),
+										Variadic: false,
+										DefaultValue: null
+									)
 								)
 							},
+							Body: new UntypedBlock(
+								OpeningBrace: new Tok(
+									typ: TokType.LeftBrace,
+									value: "{",
+									line: 1
+								),
+								Statements: new List<IUntypedAuraStatement>
+								{
+									new UntypedReturn(
+										Return: new Tok(
+											typ: TokType.Return,
+											value: "return",
+											line: 1
+										),
+										Value: new List<IUntypedAuraExpression>
+										{
+											new IntLiteral(
+												Int: new Tok(
+													typ: TokType.IntLiteral,
+													value: "5",
+													line: 1
+												),
+												Line: 1
+											)
+										},
+										Line: 1
+									)
+								},
+								ClosingBrace: new Tok(
+									typ: TokType.RightBrace,
+									value: "}",
+									line: 1
+								),
+								Line: 1
+							),
+							ReturnType: new List<AuraType>{ new AuraInt() },
+							Public: Visibility.Private,
 							Line: 1
-						),
-						ReturnType: new List<AuraType>{ new AuraInt() },
-						Public: Visibility.Private,
-						Line: 1
-					)
-				},
-				Public: Visibility.Private,
-				Implementing: new List<Tok> { new(TokType.Identifier, "IGreeter", 1) },
-				Line: 1)
-		},
-		typeof(MissingInterfaceMethodException));
+						)
+					},
+					Public: Visibility.Private,
+					Implementing: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "IGreeter",
+							line: 1
+						)
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			},
+			expected: typeof(MissingInterfaceMethodException)
+		);
 	}
 
 	[Test]
@@ -1612,98 +3792,212 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("IGreeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"IGreeter",
-				new AuraInterface("IGreeter",
-				new List<AuraNamedFunction>
-				{
-					new(
-						"f",
-						Visibility.Public,
-						new AuraFunction(
-							new List<Param>
-							{
-								new(
-									new Tok(TokType.Identifier, "i", 1),
-									new ParamType(
-										new AuraInt(),
-										false,
-										null
+				Name: "IGreeter",
+				Kind: new AuraInterface(
+					name: "IGreeter",
+					functions: new List<AuraNamedFunction>
+					{
+						new(
+							name: "f",
+							pub: Visibility.Public,
+							f: new AuraFunction(
+								fParams: new List<Param>
+								{
+									new(
+										Name: new Tok(
+											typ: TokType.Identifier,
+											value: "i",
+											line: 1
+										),
+										ParamType: new(
+											Typ: new AuraInt(),
+											Variadic: false,
+											DefaultValue: null
+										)
 									)
-								)
-							},
-							new AuraInt()
+								},
+								returnType: new AuraInt()
+							)
 						)
-					)
-				},
-				Visibility.Private)
+					},
+					pub: Visibility.Private
+				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedClass(
-				Name: new Tok(TokType.Identifier, "Greeter", 1),
-				Params: new List<Param>(),
-				Body: new List<IUntypedAuraStatement>
-				{
-					new UntypedNamedFunction(
-						Name: new Tok(TokType.Identifier, "f", 1),
-						Params: new List<Param>
-						{
-							new(
-								Name: new Tok(TokType.Identifier, "i", 1),
-								ParamType: new ParamType(
-									new AuraInt(),
-									false,
-									null
-								)
-							)
-						},
-						Body: new UntypedBlock(
-							Statements: new List<IUntypedAuraStatement>
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedClass(
+					Class: new Tok(
+						typ: TokType.Class,
+						value: "class",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "Greeter",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new List<IUntypedAuraStatement>
+					{
+						new UntypedNamedFunction(
+							Fn: new Tok(
+								typ: TokType.Fn,
+								value: "fn",
+								line: 1
+							),
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "f",
+								line: 1
+							),
+							Params: new List<Param>
 							{
-								new UntypedReturn(
-									Value: new List<IUntypedAuraExpression>{ new IntLiteral(I: 5, Line: 1) },
-									Line: 1
+								new(
+									Name: new Tok(
+										typ: TokType.Identifier,
+										value: "i",
+										line: 1
+									),
+									ParamType: new(
+										Typ: new AuraInt(),
+										Variadic: false,
+										DefaultValue: null
+									)
 								)
 							},
+							Body: new UntypedBlock(
+								OpeningBrace: new Tok(
+									typ: TokType.LeftBrace,
+									value: "{",
+									line: 1
+								),
+								Statements: new List<IUntypedAuraStatement>
+								{
+									new UntypedReturn(
+										Return: new Tok(
+											typ: TokType.Return,
+											value: "return",
+											line: 1
+										),
+										Value: new List<IUntypedAuraExpression>
+										{
+											new IntLiteral(
+												Int: new Tok(
+													typ: TokType.IntLiteral,
+													value: "5",
+													line: 1
+												),
+												Line: 1
+											)
+										},
+										Line: 1
+									)
+								},
+								ClosingBrace: new Tok(
+									typ: TokType.RightBrace,
+									value: "}",
+									line: 1
+								),
+								Line: 1
+							),
+							ReturnType: new List<AuraType>{ new AuraInt() },
+							Public: Visibility.Public,
 							Line: 1
+						)
+					},
+					Public: Visibility.Private,
+					Implementing: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "IGreeter",
+							line: 1
+						)
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new FullyTypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Methods: new List<TypedNamedFunction>
+				{
+					new(
+						Fn: new Tok(
+							typ: TokType.Fn,
+							value: "fn",
+							line: 1
 						),
-						ReturnType: new List<AuraType>{ new AuraInt() },
-						Public: Visibility.Public,
-						Line: 1
-					)
-				},
-				Public: Visibility.Private,
-				Implementing: new List<Tok> { new(TokType.Identifier, "IGreeter", 1) },
-				Line: 1)
-		});
-		MakeAssertions(typedAst, new FullyTypedClass(
-			Name: new Tok(TokType.Identifier, "Greeter", 1),
-			Params: new List<Param>(),
-			Methods: new List<TypedNamedFunction>
-			{
-				new TypedNamedFunction(
-						Name: new Tok(TokType.Identifier, "f", 1),
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "f",
+							line: 1
+						),
 						Params: new List<Param>
 						{
 							new(
-								Name: new Tok(TokType.Identifier, "i", 1),
-								ParamType: new ParamType(
-									new AuraInt(),
-									false,
-									null
+								Name: new Tok(
+									typ: TokType.Identifier,
+									value: "i",
+									line: 1
+								),
+								ParamType: new(
+									Typ: new AuraInt(),
+									Variadic: false,
+									DefaultValue: null
 								)
 							)
 						},
 						Body: new TypedBlock(
+							OpeningBrace: new Tok(
+								typ: TokType.LeftBrace,
+								value: "{",
+								line: 1
+							),
 							Statements: new List<ITypedAuraStatement>
 							{
 								new TypedReturn(
-									Value: new IntLiteral(I: 5, Line: 1),
+									Return: new Tok(
+										typ: TokType.Return,
+										value: "return",
+										line: 1
+									),
+									Value: new IntLiteral(
+										Int: new Tok(
+											typ: TokType.IntLiteral,
+											value: "5",
+											line: 1
+										),
+										Line: 1
+									),
 									Line: 1
 								)
 							},
+							ClosingBrace: new Tok(
+								typ: TokType.RightBrace,
+								value: "}",
+								line: 1
+							),
 							Typ: new AuraInt(),
 							Line: 1
 						),
@@ -1711,35 +4005,48 @@ public class TypeCheckerTest
 						Public: Visibility.Public,
 						Line: 1
 					)
-			},
-			Public: Visibility.Private,
-			Implementing: new List<AuraInterface>
-			{
-				new(
-					name: "IGreeter",
-					functions: new List<AuraNamedFunction>
-					{
-						new(
-							"f",
-							Visibility.Public,
-							new AuraFunction(
-								new List<Param>
-								{
-									new(
-										new Tok(TokType.Identifier, "i", 1),
-										new ParamType(
-											new AuraInt(),
-											false,
-											null
+				},
+				Public: Visibility.Private,
+				Implementing: new List<AuraInterface>
+				{
+					new(
+						name: "IGreeter",
+						functions: new List<AuraNamedFunction>
+						{
+							new(
+								name: "f",
+								pub: Visibility.Public,
+								f: new AuraFunction(
+									fParams: new List<Param>
+									{
+										new(
+											Name: new Tok(
+												typ: TokType.Identifier,
+												value: "i",
+												line: 1
+											),
+											ParamType: new(
+												Typ: new AuraInt(),
+												Variadic: false,
+												DefaultValue: null
+											)
 										)
-									)
-								},
-								new AuraInt()
+									},
+									returnType: new AuraInt()
+								)
 							)
-						)
-					},
-					pub: Visibility.Private) },
-			Line: 1));
+						},
+						pub: Visibility.Private
+					)
+				},
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -1747,28 +4054,81 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("IGreeter", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"IGreeter",
-				new AuraInterface("IGreeter", new List<AuraNamedFunction>(), Visibility.Private)
+				Name: "IGreeter",
+				Kind: new AuraInterface(
+					name: "IGreeter",
+					functions: new List<AuraNamedFunction>(),
+					pub: Visibility.Private
+				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedClass(
-				new Tok(TokType.Identifier, "Greeter", 1),
-				new List<Param>(),
-				new List<IUntypedAuraStatement>(),
-				Visibility.Private,
-				new List<Tok> { new(TokType.Identifier, "IGreeter", 1) },
-				1)
-		});
-		MakeAssertions(typedAst, new FullyTypedClass(
-			new Tok(TokType.Identifier, "Greeter", 1),
-			new List<Param>(),
-			new List<TypedNamedFunction>(),
-			Visibility.Private,
-			new List<AuraInterface> { new("IGreeter", new List<AuraNamedFunction>(), Visibility.Private) },
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedClass(
+					Class: new Tok(
+						typ: TokType.Class,
+						value: "class",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "Greeter",
+						line: 1
+					),
+					Params: new List<Param>(),
+					Body: new List<IUntypedAuraStatement>(),
+					Public: Visibility.Private,
+					Implementing: new List<Tok>
+					{
+						new(
+							typ: TokType.Identifier,
+							value: "IGreeter",
+							line: 1
+						)
+					},
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new FullyTypedClass(
+				Class: new Tok(
+					typ: TokType.Class,
+					value: "class",
+					line: 1
+				),
+				Name: new Tok(
+					typ: TokType.Identifier,
+					value: "Greeter",
+					line: 1
+				),
+				Params: new List<Param>(),
+				Methods: new List<TypedNamedFunction>(),
+				Public: Visibility.Private,
+				Implementing: new List<AuraInterface>
+				{
+					new(
+						name: "IGreeter",
+						functions: new List<AuraNamedFunction>(),
+						pub: Visibility.Private
+					)
+				},
+				ClosingBrace: new Tok(
+					typ: TokType.RightBrace,
+					value: "}",
+					line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -1776,25 +4136,44 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("v", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"v",
-				new AuraInt()
+				Name: "v",
+				Kind: new AuraInt()
 			)
 		);
 
 		ArrangeAndAct_Invalid(
-			new List<IUntypedAuraStatement>
+			untypedAst: new List<IUntypedAuraStatement>
 			{
 				new UntypedExpressionStmt(
-					new UntypedSet(
-						new UntypedVariable(
-							new Tok(TokType.Identifier, "v", 1),
-							1),
-						new Tok(TokType.Identifier, "name", 1),
-						new StringLiteral("Bob", 1),
-						1),
-					1)
+					Expression: new UntypedSet(
+						Obj: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "v",
+								line: 1
+							),
+							Line: 1
+						),
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "name",
+							line: 1
+						),
+						Value: new StringLiteral(
+							String: new Tok(
+								typ: TokType.StringLiteral,
+								value: "Bob",
+								line: 1
+							),
+							Line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
 			},
-			typeof(CannotSetOnNonClassException));
+			expected: typeof(CannotSetOnNonClassException)
+		);
 	}
 
 	[Test]
@@ -1802,31 +4181,58 @@ public class TypeCheckerTest
 	{
 		_symbolsTable.Setup(v => v.GetSymbol("v", It.IsAny<string>())).Returns(
 			new AuraSymbol(
-				"v",
-				new AuraInt()
+				Name: "v",
+				Kind: new AuraInt()
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedExpressionStmt(
-				new UntypedIs(
-					new UntypedVariable(
-						new Tok(TokType.Identifier, "v", 1),
-						1),
-					new Tok(TokType.Identifier, "IGreeter", 1),
-					1),
-				1)
-		});
-		MakeAssertions(typedAst, new TypedExpressionStmt(
-			new TypedIs(
-				new TypedVariable(
-					new Tok(TokType.Identifier, "v", 1),
-					new AuraInt(),
-					1),
-				new AuraInterface("IGreeter", new List<AuraNamedFunction>(), Visibility.Private),
-				1),
-			1));
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedExpressionStmt(
+					Expression: new UntypedIs(
+						Expr: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "v",
+								line: 1
+							),
+							Line: 1
+						),
+						Expected: new Tok(
+							typ: TokType.Identifier,
+							value: "IGreeter",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedExpressionStmt(
+				Expression: new TypedIs(
+					Expr: new TypedVariable(
+						Name: new Tok(
+							typ: TokType.Identifier,
+							value: "v",
+							line: 1
+						),
+						Typ: new AuraInt(),
+						Line: 1
+					),
+					Expected: new AuraInterface(
+						name: "IGreeter",
+						functions: new List<AuraNamedFunction>(),
+						pub: Visibility.Private
+					),
+					Line: 1
+				),
+				Line: 1
+			)
+		);
 	}
 
 	[Test]
@@ -1834,6 +4240,11 @@ public class TypeCheckerTest
 	{
 		_enclosingFunctionDeclarationStore.Setup(f => f.Peek()).Returns(
 			new UntypedNamedFunction(
+				Fn: new Tok(
+					typ: TokType.Fn,
+					value: "fn",
+					line: 1
+				),
 				Name: new Tok(
 					typ: TokType.Identifier,
 					value: "f",
@@ -1841,10 +4252,26 @@ public class TypeCheckerTest
 				),
 				Params: new List<Param>(),
 				Body: new UntypedBlock(
+					OpeningBrace: new Tok(
+						typ: TokType.LeftBrace,
+						value: "{",
+						line: 1
+					),
 					Statements: new List<IUntypedAuraStatement>(),
+					ClosingBrace: new Tok(
+						typ: TokType.RightBrace,
+						value: "}",
+						line: 1
+					),
 					Line: 1
 				),
-				ReturnType: new List<AuraType> { new AuraResult(new AuraString(), new AuraError()) },
+				ReturnType: new List<AuraType>
+				{
+					new AuraResult(
+						success: new AuraString(),
+						failure: new AuraError()
+					)
+				},
 				Public: Visibility.Public,
 				Line: 1
 			)
@@ -1857,80 +4284,139 @@ public class TypeCheckerTest
 					pub: Visibility.Public,
 					f: new AuraFunction(
 						fParams: new List<Param>(),
-						returnType: new AuraResult(new AuraString(), new AuraError())
+						returnType: new AuraResult(
+							success: new AuraString(),
+							failure: new AuraError()
+						)
 					)
 				)
 			)
 		);
 
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedCheck(
-				Call: new UntypedCall(
-					Callee: new UntypedVariable(
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedCheck(
+					Check: new Tok(
+						typ: TokType.Check,
+						value: "check",
+						line: 1
+					),
+					Call: new UntypedCall(
+						Callee: new UntypedVariable(
+							Name: new Tok(
+								typ: TokType.Identifier,
+								value: "c",
+								line: 1
+							),
+							Line: 1
+						),
+						Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+						ClosingParen: new Tok(
+							typ: TokType.RightParen,
+							value: ")",
+							line: 1
+						),
+						Line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedCheck(
+				Check: new Tok(
+					typ: TokType.Check,
+					value: "check",
+					line: 1
+				),
+				Call: new TypedCall(
+					Callee: new TypedVariable(
 						Name: new Tok(
 							typ: TokType.Identifier,
 							value: "c",
 							line: 1
 						),
+						Typ: new AuraNamedFunction(
+							name: "c",
+							pub: Visibility.Public,
+							f: new AuraFunction(
+								fParams: new List<Param>(),
+								returnType: new AuraResult(
+									success: new AuraString(),
+									failure: new AuraError()
+								)
+							)
+						),
 						Line: 1
 					),
-					Arguments: new List<(Tok?, IUntypedAuraExpression)>(),
+					Arguments: new List<ITypedAuraExpression>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Typ: new AuraResult(
+						success: new AuraString(),
+						failure: new AuraError()
+					),
 					Line: 1
 				),
 				Line: 1
 			)
-		});
-		MakeAssertions(typedAst, new TypedCheck(
-			Call: new TypedCall(
-				Callee: new TypedVariable(
-					Name: new Tok(
-						typ: TokType.Identifier,
-						value: "c",
-						line: 1
-					),
-					Typ: new AuraNamedFunction(
-						name: "c",
-						pub: Visibility.Public,
-						f: new AuraFunction(
-							fParams: new List<Param>(),
-							returnType: new AuraResult(new AuraString(), new AuraError())
-						)
-					),
-					Line: 1
-				),
-				Arguments: new List<ITypedAuraExpression>(),
-				Typ: new AuraResult(new AuraString(), new AuraError()),
-				Line: 1
-			),
-			Line: 1
-		));
+		);
 	}
 
 	[Test]
 	public void TestTypeCheck_Struct()
 	{
-		var typedAst = ArrangeAndAct(new List<IUntypedAuraStatement>
-		{
-			new UntypedStruct(
+		var typedAst = ArrangeAndAct(
+			untypedAst: new List<IUntypedAuraStatement>
+			{
+				new UntypedStruct(
+					Struct: new Tok(
+						typ: TokType.Struct,
+						value: "struct",
+						line: 1
+					),
+					Name: new Tok(
+						typ: TokType.Identifier,
+						value: "s",
+						line: 1
+					),
+					Params: new List<Param>(),
+					ClosingParen: new Tok(
+						typ: TokType.RightParen,
+						value: ")",
+						line: 1
+					),
+					Line: 1
+				)
+			}
+		);
+		MakeAssertions(
+			typedAst: typedAst,
+			expected: new TypedStruct(
+				Struct: new Tok(
+					typ: TokType.Struct,
+					value: "struct",
+					line: 1
+				),
 				Name: new Tok(
 					typ: TokType.Identifier,
 					value: "s",
 					line: 1
 				),
 				Params: new List<Param>(),
+				ClosingParen: new Tok(
+					typ: TokType.RightParen,
+					value: ")",
+					line: 1
+				),
 				Line: 1
 			)
-		});
-		MakeAssertions(typedAst, new TypedStruct(
-			Name: new Tok(
-				typ: TokType.Identifier,
-				value: "s",
-				line: 1
-			),
-			Params: new List<Param>(),
-			Line: 1
-		));
+		);
 	}
 
 	private List<ITypedAuraStatement> ArrangeAndAct(List<IUntypedAuraStatement> untypedAst)
@@ -1949,7 +4435,10 @@ public class TypeCheckerTest
 		}
 		catch (TypeCheckerExceptionContainer e)
 		{
-			Assert.That(e.Exs.First(), Is.TypeOf(expected));
+			Assert.That(
+				actual: e.Exs.First(),
+				expression: Is.TypeOf(expected)
+			);
 		}
 	}
 
@@ -1960,8 +4449,18 @@ public class TypeCheckerTest
 			var untypedAstWithMod = new List<IUntypedAuraStatement>
 			{
 				new UntypedMod(
-					new Tok(TokType.Identifier, "main", 1),
-					1)
+					Mod: new Tok(
+						typ: TokType.Mod,
+						value: "mod",
+						line: 1
+					),
+					Value: new Tok(
+						typ: TokType.Identifier,
+						value: "main",
+						line: 1
+					),
+					Line: 1
+				)
 			};
 			untypedAstWithMod.AddRange(untypedAst);
 			return untypedAstWithMod;
@@ -1974,12 +4473,21 @@ public class TypeCheckerTest
 	{
 		Assert.Multiple(() =>
 		{
-			Assert.That(typedAst, Is.Not.Null);
-			Assert.That(typedAst, Has.Count.EqualTo(2));
+			Assert.That(
+				actual: typedAst,
+				expression: Is.Not.Null
+			);
+			Assert.That(
+				actual: typedAst,
+				expression: Has.Count.EqualTo(2)
+			);
 
 			var expectedJson = JsonConvert.SerializeObject(expected);
 			var actualJson = JsonConvert.SerializeObject(typedAst[1]);
-			Assert.That(actualJson, Is.EqualTo(expectedJson));
+			Assert.That(
+				actual: actualJson,
+				expression: Is.EqualTo(expectedJson)
+			);
 		});
 	}
 }

--- a/AuraLang/AST/AstNode.cs
+++ b/AuraLang/AST/AstNode.cs
@@ -1,6 +1,9 @@
-﻿namespace AuraLang.AST;
+﻿using Range = AuraLang.Location.Range;
+
+namespace AuraLang.AST;
 
 public interface IAuraAstNode
 {
+	public Range Range { get; }
 	public int Line { get; }
 }

--- a/AuraLang/AST/ILiteral.cs
+++ b/AuraLang/AST/ILiteral.cs
@@ -1,5 +1,8 @@
-﻿using AuraLang.Types;
+﻿using System.Globalization;
+using AuraLang.Token;
+using AuraLang.Types;
 using AuraLang.Visitor;
+using Range = AuraLang.Location.Range;
 
 namespace AuraLang.AST;
 
@@ -14,46 +17,49 @@ public interface ILiteral<out T> : ILiteral
 /// Represents an integer literal
 /// </summary>
 /// <param name="I">The integer value</param>
-public record IntLiteral(long I, int Line) : ILiteral<long>
+public record IntLiteral(Tok Int, int Line) : ILiteral<long>
 {
 	public T Accept<T>(IUntypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public T Accept<T>(ITypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public AuraType Typ => new AuraInt();
-	public long Value => I;
+	public long Value => int.Parse(Int.Value);
 	public override string ToString() => $"{Value}";
+	public Range Range => Int.Range;
 }
 
 /// <summary>
 /// Represents a float literal
 /// </summary>
 /// <param name="F">The float value</param>
-public record FloatLiteral(double F, int Line) : ILiteral<double>
+public record FloatLiteral(Tok Float, int Line) : ILiteral<double>
 {
 	public T Accept<T>(IUntypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public T Accept<T>(ITypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public AuraType Typ => new AuraFloat();
-	public double Value => F;
+	public double Value => float.Parse(Float.Value, CultureInfo.InvariantCulture);
 	public override string ToString() => $"{Value}";
+	public Range Range => Float.Range;
 }
 
 /// <summary>
 /// Represents a string literal
 /// </summary>
 /// <param name="S">The string value</param>
-public record StringLiteral(string S, int Line) : ILiteral<string>
+public record StringLiteral(Tok String, int Line) : ILiteral<string>
 {
 	public T Accept<T>(IUntypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public T Accept<T>(ITypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public AuraType Typ => new AuraString();
-	public string Value => S;
+	public string Value => String.Value;
 	public override string ToString() => $"{Value}";
+	public Range Range => String.Range;
 }
 
 /// <summary>
 /// Represents a list literal
 /// </summary>
 /// <param name="L">The list value</param>
-public record ListLiteral<T>(List<T> L, AuraType Kind, int Line) : ILiteral<List<T>>
+public record ListLiteral<T>(Tok OpeningBracket, List<T> L, AuraType Kind, Tok ClosingBrace, int Line) : ILiteral<List<T>>
 	where T : IAuraAstNode
 {
 	public U Accept<U>(IUntypedAuraExprVisitor<U> visitor) => visitor.Visit(this);
@@ -61,6 +67,10 @@ public record ListLiteral<T>(List<T> L, AuraType Kind, int Line) : ILiteral<List
 	public AuraType Typ => new AuraList(Kind);
 	public List<T> Value => L;
 	public override string ToString() => $"{Value}";
+	public Range Range => new(
+		start: OpeningBracket.Range.Start,
+		end: ClosingBrace.Range.End
+	);
 }
 
 /// <summary>
@@ -77,7 +87,7 @@ public record ListLiteral<T>(List<T> L, AuraType Kind, int Line) : ILiteral<List
 /// match their expected type.
 /// </summary>
 /// <param name="M">The map value</param>
-public record MapLiteral<TK, TV>(Dictionary<TK, TV> M, AuraType KeyType, AuraType ValueType, int Line) : ILiteral<Dictionary<TK, TV>>
+public record MapLiteral<TK, TV>(Tok Map, Dictionary<TK, TV> M, AuraType KeyType, AuraType ValueType, Tok ClosingBrace, int Line) : ILiteral<Dictionary<TK, TV>>
 	where TK : IAuraAstNode
 	where TV : IAuraAstNode
 {
@@ -86,30 +96,36 @@ public record MapLiteral<TK, TV>(Dictionary<TK, TV> M, AuraType KeyType, AuraTyp
 	public AuraType Typ => new AuraMap(KeyType, ValueType);
 	public Dictionary<TK, TV> Value => M;
 	public override string ToString() => $"{Value}";
+	public Range Range => new(
+		start: Map.Range.Start,
+		end: ClosingBrace.Range.End
+	);
 }
 
 /// <summary>
 /// Represents a boolean literal
 /// </summary>
 /// <param name="B">The boolean value</param>
-public record BoolLiteral(bool B, int Line) : ILiteral<bool>
+public record BoolLiteral(Tok Bool, int Line) : ILiteral<bool>
 {
 	public T Accept<T>(IUntypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public T Accept<T>(ITypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public AuraType Typ => new AuraBool();
-	public bool Value => B;
+	public bool Value => bool.Parse(Bool.Value);
 	public override string ToString() => $"{Value}";
+	public Range Range => Bool.Range;
 }
 
 /// <summary>
 /// Represents a char literal
 /// </summary>
 /// <param name="C">The char value</param>
-public record CharLiteral(char C, int Line) : ILiteral<char>
+public record CharLiteral(Tok Char, int Line) : ILiteral<char>
 {
 	public T Accept<T>(IUntypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public T Accept<T>(ITypedAuraExprVisitor<T> visitor) => visitor.Visit(this);
 	public AuraType Typ => new AuraChar();
-	public char Value => C;
+	public char Value => char.Parse(Char.Value);
 	public override string ToString() => $"{Value}";
+	public Range Range => Char.Range;
 }

--- a/AuraLang/AST/PartialAst.cs
+++ b/AuraLang/AST/PartialAst.cs
@@ -2,6 +2,7 @@
 using AuraLang.Token;
 using AuraLang.Types;
 using AuraLang.Visitor;
+using Range = AuraLang.Location.Range;
 
 namespace AuraLang.AST;
 
@@ -12,12 +13,16 @@ namespace AuraLang.AST;
 /// <param name="Params">The partially type function's parameters</param>
 /// <param name="Body">The partially typed function's body</param>
 /// <param name="ReturnType">The partially typed function's return type</param>
-public record PartiallyTypedFunction(Tok Name, List<Param> Params, UntypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : ITypedAuraStatement, IUntypedFunction
+public record PartiallyTypedFunction(Tok Fn, Tok Name, List<Param> Params, UntypedBlock Body, AuraType ReturnType, Visibility Public, int Line) : ITypedAuraStatement, IUntypedFunction
 {
 	public T Accept<T>(ITypedAuraStmtVisitor<T> visitor) => visitor.Visit(this);
 	public AuraType Typ => ReturnType;
 	public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
 	public List<Param> GetParams() => Params;
+	public Range Range => new(
+		start: Public == Visibility.Public ? Fn.Range.Start with { Character = Fn.Range.Start.Character - 4 } : Fn.Range.Start,
+		end: Body.Range.End
+	);
 }
 
 /// <summary>
@@ -27,9 +32,13 @@ public record PartiallyTypedFunction(Tok Name, List<Param> Params, UntypedBlock 
 /// <param name="Params">The partially typed class's parameters</param>
 /// <param name="Methods">The partially typed class's methods</param>
 /// <param name="Public">Indicates if the partially typed class is public or not</param>
-public record PartiallyTypedClass(Tok Name, List<Param> Params, List<AuraNamedFunction> Methods, Visibility Public, AuraType Typ, int Line) : ITypedAuraStatement, IUntypedFunction
+public record PartiallyTypedClass(Tok Class, Tok Name, List<Param> Params, List<AuraNamedFunction> Methods, Visibility Public, Tok ClosingBrace, AuraType Typ, int Line) : ITypedAuraStatement, IUntypedFunction
 {
 	public T Accept<T>(ITypedAuraStmtVisitor<T> visitor) => visitor.Visit(this);
 	public List<ParamType> GetParamTypes() => Params.Select(param => param.ParamType).ToList();
 	public List<Param> GetParams() => Params;
+	public Range Range => new(
+		start: Class.Range.Start,
+		end: ClosingBrace.Range.End
+	);
 }

--- a/AuraLang/Compiler/Compiler.cs
+++ b/AuraLang/Compiler/Compiler.cs
@@ -391,33 +391,47 @@ public class AuraCompiler : ITypedAuraStmtVisitor<string>, ITypedAuraExprVisitor
 		string callee;
 		if (IsStdlibPkgType(get.Obj.Typ))
 		{
-			_goDocument.WriteStmt(Visit(new TypedImport(
-				Package: new Tok(
-					typ: TokType.Identifier,
-					value: $"aura/{AuraTypeToString(get.Obj.Typ)}",
-					line: 1
+			_goDocument.WriteStmt(
+				s: Visit(
+					i: new TypedImport(
+						Import: new Tok(
+							typ: TokType.Import,
+							value: "import",
+							line: 1
+						),
+						Package: new Tok(
+							typ: TokType.Identifier,
+							value: $"aura/{AuraTypeToString(get.Obj.Typ)}",
+							line: 1
+						),
+						Alias: new Tok(
+							typ: TokType.Identifier,
+							value: AuraTypeToString(get.Obj.Typ),
+							line: 1
+						),
+						Line: 1
+					)
 				),
-				Alias: new Tok(
-					typ: TokType.Identifier,
-					value: AuraTypeToString(get.Obj.Typ),
-					line: 1
-				),
-				Line: 1
-			)),
-			1,
-			new TypedImport(
-				Package: new Tok(
-					typ: TokType.Identifier,
-					value: $"aura/{AuraTypeToString(get.Obj.Typ)}",
-					line: 1
-				),
-				Alias: new Tok(
-					typ: TokType.Identifier,
-					value: AuraTypeToString(get.Obj.Typ),
-					line: 1
-				),
-				Line: 1
-			));
+				line: 1,
+				typ: new TypedImport(
+					Import: new Tok(
+						typ: TokType.Import,
+						value: "import",
+						line: 1
+					),
+					Package: new Tok(
+						typ: TokType.Identifier,
+						value: $"aura/{AuraTypeToString(get.Obj.Typ)}",
+						line: 1
+					),
+					Alias: new Tok(
+						typ: TokType.Identifier,
+						value: AuraTypeToString(get.Obj.Typ),
+						line: 1
+					),
+					Line: 1
+				)
+			);
 			callee = $"{AuraTypeToString(get.Obj.Typ)}.{ConvertSnakeCaseToCamelCase(get.Name.Value)}";
 		}
 		else
@@ -479,7 +493,7 @@ public class AuraCompiler : ITypedAuraStmtVisitor<string>, ITypedAuraExprVisitor
 	public string Visit(IntLiteral literal) => $"{literal.Value}";
 
 	public string Visit(FloatLiteral literal) =>
-		string.Format(CultureInfo.InvariantCulture, "{0:0.0######}", literal.Value);
+		string.Format(CultureInfo.InvariantCulture, "{0:0.0}", literal.Value);
 
 	public string Visit(BoolLiteral literal) => literal.Value ? "true" : "false";
 
@@ -706,6 +720,11 @@ public class AuraCompiler : ITypedAuraStmtVisitor<string>, ITypedAuraExprVisitor
 	private string AddPreludePrefix(string name)
 	{
 		var typedImport = new TypedImport(
+			Import: new Tok(
+				typ: TokType.Import,
+				value: "import",
+				line: 1
+			),
 			Package: new Tok(
 				typ: TokType.Identifier,
 				value: $"{ProjectName}/prelude",

--- a/AuraLang/Position/Position.cs
+++ b/AuraLang/Position/Position.cs
@@ -1,23 +1,21 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace AuraLang.Location;
+﻿namespace AuraLang.Location;
 
 /// <summary>
 /// Represents a single position in an Aura source file
 /// </summary>
-public readonly struct Position
+public record Position
 {
 	/// <summary>
 	/// The zero-based character position. Because Aura source files are indented with four
 	/// spaces instead of a single tab character, the first character on a line with a single
 	/// indentation would be at position 4.
 	/// </summary>
-	readonly int Character;
+	public int Character;
 	/// <summary>
 	/// The zero-based lined in the Aura source file. Blank lines are included when counting
 	/// lines.
 	/// </summary>
-	readonly int Line;
+	public int Line;
 
 	public Position(int character, int line)
 	{
@@ -30,28 +28,6 @@ public readonly struct Position
 		Character = 0;
 		Line = 0;
 	}
-
-	public override bool Equals([NotNullWhen(true)] object? obj)
-	{
-		if (obj is null) return false;
-		if (obj is not Position p) return false;
-		if (p.Character != Character) return false;
-		if (p.Line != Line) return false;
-
-		return true;
-	}
-
-	public static bool operator ==(Position left, Position right)
-	{
-		return left.Equals(right);
-	}
-
-	public static bool operator !=(Position left, Position right)
-	{
-		return !(left == right);
-	}
-
-	public override int GetHashCode() => ToString().GetHashCode();
 
 	public override string ToString() => $"{Line}:{Character}";
 }

--- a/AuraLang/Position/Range.cs
+++ b/AuraLang/Position/Range.cs
@@ -1,21 +1,18 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace AuraLang.Location;
+﻿namespace AuraLang.Location;
 
 /// <summary>
-/// Represents a range in an Aura source file, with both the starting and ending positions
-/// included. Ranges can be used to place both tokens and AST nodes in an source file.
+/// Represents a range in an Aura source file. Ranges can be used to place both tokens and AST nodes in an source file.
 /// </summary>
-public readonly struct Range
+public record Range
 {
 	/// <summary>
 	/// The starting position, inclusive
 	/// </summary>
-	readonly Position Start;
+	public Position Start;
 	/// <summary>
-	/// The ending position, inclusive
+	/// The ending position, exclusive
 	/// </summary>
-	readonly Position End;
+	public Position End;
 
 	public Range(Position start, Position end)
 	{
@@ -28,28 +25,6 @@ public readonly struct Range
 		Start = new Position();
 		End = new Position();
 	}
-
-	public override bool Equals([NotNullWhen(true)] object? obj)
-	{
-		if (obj is null) return false;
-		if (obj is not Range r) return false;
-		if (r.Start != Start) return false;
-		if (r.End != End) return false;
-
-		return true;
-	}
-
-	public static bool operator ==(Range left, Range right)
-	{
-		return left.Equals(right);
-	}
-
-	public static bool operator !=(Range left, Range right)
-	{
-		return !(left == right);
-	}
-
-	public override int GetHashCode() => ToString().GetHashCode();
 
 	public override string ToString() => $"{Start}-{End}";
 }

--- a/AuraLang/Types/AuraType.cs
+++ b/AuraLang/Types/AuraType.cs
@@ -1,6 +1,7 @@
 ﻿using AuraLang.AST;
 using AuraLang.Shared;
 using AuraLang.Stdlib;
+using AuraLang.Token;
 
 namespace AuraLang.Types;
 
@@ -70,7 +71,15 @@ public class AuraInt : AuraType, IDefaultable
 	public override bool IsSameType(AuraType other) => other is AuraInt;
 
 	public override string ToString() => "int";
-	public ITypedAuraExpression Default(int line) => new IntLiteral(0, line);
+	public ITypedAuraExpression Default(int line)
+		=> new IntLiteral(
+			Int: new Tok(
+				typ: TokType.IntLiteral,
+				value: "0",
+				line: line
+			),
+			Line: line
+		);
 }
 
 /// <summary>
@@ -81,7 +90,15 @@ public class AuraFloat : AuraType, IDefaultable
 	public override bool IsSameType(AuraType other) => other is AuraFloat;
 
 	public override string ToString() => "float";
-	public ITypedAuraExpression Default(int line) => new FloatLiteral(0.0, line);
+	public ITypedAuraExpression Default(int line)
+		=> new FloatLiteral(
+			Float: new Tok(
+				typ: TokType.Float,
+				value: "0.0",
+				line: line
+			),
+			Line: line
+		);
 }
 
 /// <summary>
@@ -96,7 +113,15 @@ public class AuraString : AuraType, IIterable, IIndexable, IRangeIndexable, IDef
 	public AuraType IndexingType() => new AuraInt();
 	public AuraType GetIndexedType() => new AuraChar();
 	public AuraType GetRangeIndexedType() => new AuraString();
-	public ITypedAuraExpression Default(int line) => new StringLiteral(string.Empty, line);
+	public ITypedAuraExpression Default(int line)
+		=> new StringLiteral(
+			String: new Tok(
+				typ: TokType.String,
+				value: string.Empty,
+				line: line
+			),
+			Line: line
+		);
 
 	public AuraType? Get(string attribute)
 	{
@@ -115,7 +140,15 @@ public class AuraBool : AuraType, IDefaultable
 	public override bool IsSameType(AuraType other) => other is AuraBool;
 
 	public override string ToString() => "bool";
-	public ITypedAuraExpression Default(int line) => new BoolLiteral(false, line);
+	public ITypedAuraExpression Default(int line)
+		=> new BoolLiteral(
+			Bool: new Tok(
+				typ: TokType.Bool,
+				value: "false",
+				line: line
+			),
+			Line: line
+		);
 }
 
 /// <summary>
@@ -144,7 +177,21 @@ public class AuraList : AuraType, IIterable, IIndexable, IRangeIndexable, IDefau
 	public AuraType GetRangeIndexedType() => new AuraList(Kind);
 
 	public ITypedAuraExpression Default(int line) =>
-		new ListLiteral<ITypedAuraExpression>(new List<ITypedAuraExpression>(), new AuraList(Kind), line);
+		new ListLiteral<ITypedAuraExpression>(
+			OpeningBracket: new Tok(
+				typ: TokType.LeftBracket,
+				value: "[",
+				line: line
+			),
+			L: new List<ITypedAuraExpression>(),
+			Kind: new AuraList(Kind),
+			ClosingBrace: new Tok(
+				typ: TokType.RightBrace,
+				value: "}",
+				line: line
+			),
+			Line: line
+		);
 
 	public AuraType? Get(string attribute)
 	{
@@ -463,7 +510,21 @@ public class AuraMap : AuraType, IIndexable, IDefaultable
 
 	public ITypedAuraExpression Default(int line) =>
 		new MapLiteral<ITypedAuraExpression, ITypedAuraExpression>(
-			new Dictionary<ITypedAuraExpression, ITypedAuraExpression>(), Key, Value, line);
+			Map: new Tok(
+				typ: TokType.Map,
+				value: "map",
+				line: line
+			),
+			M: new Dictionary<ITypedAuraExpression, ITypedAuraExpression>(),
+			KeyType: Key,
+			ValueType: Value,
+			ClosingBrace: new Tok(
+				typ: TokType.RightBrace,
+				value: "}",
+				line: line
+			),
+			Line: line
+		);
 }
 
 public class AuraError : AuraType, IGettable, IImportableModule, INilable


### PR DESCRIPTION
* All AST nodes have a `Range` attribute
* This will help when sending diagnostics from the LSP server to the LSP client
* The AST node's range is determined by the range of its tokens