### PR TITLE
Add `Range` to exceptions

### DIFF
--- a/AuraLang/ErrorReporter/ErrorReporter.cs
+++ b/AuraLang/ErrorReporter/ErrorReporter.cs
@@ -1,11 +1,11 @@
 ﻿using AuraLang.Exceptions;
 
-namespace AuraLang.Parser;
+namespace AuraLang.ErrorReporter;
 
 public class ErrorReporter
 {
 	private readonly List<AuraException> _errors = new();
-	private readonly string _sep = "\n\n\n";
+	private const string Sep = "\n\n\n";
 
 	public void Report(TextWriter tw)
 	{
@@ -15,8 +15,8 @@ public class ErrorReporter
 	public string Format()
 	{
 		return _errors
-			.Select(e => $"[{e.Line}] {e.Message}")
-			.Aggregate("", (prev, curr) => prev + _sep + curr);
+			.Select(e => $"[{e.Range.Start.Line}] {e.Message}")
+			.Aggregate("", (prev, curr) => prev + Sep + curr);
 	}
 
 	public void Add(AuraException ex)

--- a/AuraLang/Exceptions/Aura.cs
+++ b/AuraLang/Exceptions/Aura.cs
@@ -1,11 +1,13 @@
-﻿namespace AuraLang.Exceptions;
+﻿using Range = AuraLang.Location.Range;
+
+namespace AuraLang.Exceptions;
 
 public abstract class AuraExceptionContainer : Exception
 {
 	public readonly List<AuraException> Exs = new();
-	protected string FilePath { get; init; }
+	private string FilePath { get; }
 
-	public AuraExceptionContainer(string filePath)
+	protected AuraExceptionContainer(string filePath)
 	{
 		FilePath = filePath;
 	}
@@ -21,13 +23,18 @@ public abstract class AuraExceptionContainer : Exception
 
 public abstract class AuraException : Exception
 {
-	public int Line { get; }
+	public Range Range { get; }
 
-	protected AuraException(string message, int line) : base(message)
+	protected AuraException(string message, Range range) : base(message)
 	{
-		Line = line;
+		Range = range;
 	}
 
-	public string Error(string filePath) => $"[{filePath} line {Line}] {Message}";
+	public string Error(string filePath)
+	{
+		// The starting and ending positions in the range store the line as a 0-based index, so we increment the
+		// line by 1 to get a value that humans expect.
+		return $"[{filePath} line {Range.Start.Line + 1}] {Message}";
+	}
 }
 

--- a/AuraLang/Exceptions/Compiler/Compiler.cs
+++ b/AuraLang/Exceptions/Compiler/Compiler.cs
@@ -1,25 +1,26 @@
 ﻿using AuraLang.AST;
+using Range = AuraLang.Location.Range;
 
 namespace AuraLang.Exceptions.Compiler;
 
 public abstract class CompilerException : AuraException
 {
-	protected CompilerException(string message, int line) : base(message, line) { }
+	protected CompilerException(string message, Range range) : base(message, range) { }
 }
 
 public class UnknownStatementException : CompilerException
 {
-	public UnknownStatementException(ITypedAuraStatement stmt, int line)
-		: base($"Unknown statement: {stmt}", line) { }
+	public UnknownStatementException(ITypedAuraStatement stmt, Range range)
+		: base($"Unknown statement: {stmt}", range) { }
 }
 
 public class UnknownExpressionException : CompilerException
 {
-	public UnknownExpressionException(ITypedAuraExpression expr, int line)
-		: base($"Unknown expression: {expr}", line) { }
+	public UnknownExpressionException(ITypedAuraExpression expr, Range range)
+		: base($"Unknown expression: {expr}", range) { }
 }
 
 public class DirectoryCannotContainMultipleModulesException : CompilerException
 {
-	public DirectoryCannotContainMultipleModulesException(int line) : base("Directory cannot contain multiple modules", line) { }
+	public DirectoryCannotContainMultipleModulesException(Range range) : base("Directory cannot contain multiple modules", range) { }
 }

--- a/AuraLang/Exceptions/Parser/Parser.cs
+++ b/AuraLang/Exceptions/Parser/Parser.cs
@@ -1,196 +1,198 @@
-﻿namespace AuraLang.Exceptions.Parser;
+﻿using Range = AuraLang.Location.Range;
+
+namespace AuraLang.Exceptions.Parser;
 
 public abstract class ParserException : AuraException
 {
-	protected ParserException(string message, int line) : base(message, line) { }
+	protected ParserException(string message, Range range) : base(message, range) { }
 }
 
 public class TooManyParametersException : ParserException
 {
-	public TooManyParametersException(int limit, int line) : base($"Cannot have more than {limit} parameters", line) { }
+	public TooManyParametersException(int limit, Range range) : base($"Cannot have more than {limit} parameters", range) { }
 }
 
 public class ExpectParameterNameException : ParserException
 {
-	public ExpectParameterNameException(int line) : base("Expected parameter name", line) { }
+	public ExpectParameterNameException(Range range) : base("Expected parameter name", range) { }
 }
 
 public class ExpectColonAfterParameterName : ParserException
 {
-	public ExpectColonAfterParameterName(string found, int line) : base($"Expected `:` after parameter name, but found `{found}` instead", line) { }
+	public ExpectColonAfterParameterName(string found, Range range) : base($"Expected `:` after parameter name, but found `{found}` instead", range) { }
 }
 
 public class VariadicSignifierMustHaveThreeDots : ParserException
 {
-	public VariadicSignifierMustHaveThreeDots(int line) : base("Variadic signifier must have three dots", line) { }
+	public VariadicSignifierMustHaveThreeDots(Range range) : base("Variadic signifier must have three dots", range) { }
 }
 
 public class ExpectEitherRightParenOrCommaAfterParam : ParserException
 {
-	public ExpectEitherRightParenOrCommaAfterParam(string found, int line)
-		: base($"Expected either right paren or comma after param, but found `{found}` instead", line) { }
+	public ExpectEitherRightParenOrCommaAfterParam(string found, Range range)
+		: base($"Expected either right paren or comma after param, but found `{found}` instead", range) { }
 }
 
 public class ExpectParameterTypeException : ParserException
 {
-	public ExpectParameterTypeException(string found, int line) : base($"Expected parameter type, but found `{found}` instead", line) { }
+	public ExpectParameterTypeException(string found, Range range) : base($"Expected parameter type, but found `{found}` instead", range) { }
 }
 
 public class UnterminatedListLiteralException : ParserException
 {
-	public UnterminatedListLiteralException(int line) : base("Unterminated list literal", line) { }
+	public UnterminatedListLiteralException(Range range) : base("Unterminated list literal", range) { }
 }
 
 public class ExpectLeftBracketException : ParserException
 {
-	public ExpectLeftBracketException(string found, int line)
-		: base($"Expected `[` after map keyword, but found `{found}` instead", line) { }
+	public ExpectLeftBracketException(string found, Range range)
+		: base($"Expected `[` after map keyword, but found `{found}` instead", range) { }
 }
 
 public class ExpectColonBetweenMapTypesException : ParserException
 {
-	public ExpectColonBetweenMapTypesException(string found, int line)
-		: base($"Expected colon between map types, but found `{found}` instead", line) { }
+	public ExpectColonBetweenMapTypesException(string found, Range range)
+		: base($"Expected colon between map types, but found `{found}` instead", range) { }
 }
 
 public class UnterminatedMapTypeSignatureException : ParserException
 {
-	public UnterminatedMapTypeSignatureException(int line) : base("Unterminated map type signature", line) { }
+	public UnterminatedMapTypeSignatureException(Range range) : base("Unterminated map type signature", range) { }
 }
 
 public class UnexpectedTypeException : ParserException
 {
-	public UnexpectedTypeException(string found, int line) : base($"Type `{found}` was unexpected", line) { }
+	public UnexpectedTypeException(string found, Range range) : base($"Type `{found}` was unexpected", range) { }
 }
 
 public class InvalidTokenAfterPubKeywordException : ParserException
 {
-	public InvalidTokenAfterPubKeywordException(string found, int line)
-		: base($"Token `{found}` may not come directly after `pub` keyword", line) { }
+	public InvalidTokenAfterPubKeywordException(string found, Range range)
+		: base($"Token `{found}` may not come directly after `pub` keyword", range) { }
 }
 
 public class ExpectIdentifierException : ParserException
 {
-	public ExpectIdentifierException(string found, int line) : base($"Expected identifier, but found `{found}` instead", line) { }
+	public ExpectIdentifierException(string found, Range range) : base($"Expected identifier, but found `{found}` instead", range) { }
 }
 
 public class ExpectSemicolonException : ParserException
 {
-	public ExpectSemicolonException(string found, int line) : base($"Expected semicolon, but found `{found}` instead", line) { }
+	public ExpectSemicolonException(string found, Range range) : base($"Expected semicolon, but found `{found}` instead", range) { }
 }
 
 public class InvalidTokenAfterMutKeywordException : ParserException
 {
-	public InvalidTokenAfterMutKeywordException(string found, int line)
-		: base($"Token `{found}` may not come directly after mut keyword", line) { }
+	public InvalidTokenAfterMutKeywordException(string found, Range range)
+		: base($"Token `{found}` may not come directly after mut keyword", range) { }
 }
 
 public class ExpectLeftParenException : ParserException
 {
-	public ExpectLeftParenException(string found, int line) : base($"Expected left paren, but found `{found}` instead", line) { }
+	public ExpectLeftParenException(string found, Range range) : base($"Expected left paren, but found `{found}` instead", range) { }
 }
 
 public class ExpectRightParenException : ParserException
 {
-	public ExpectRightParenException(string found, int line) : base($"Expected right paren, but found `{found}` instead", line) { }
+	public ExpectRightParenException(string found, Range range) : base($"Expected right paren, but found `{found}` instead", range) { }
 }
 
 public class ExpectLeftBraceException : ParserException
 {
-	public ExpectLeftBraceException(string found, int line) : base($"Expected left brace, but found `{found}` instead", line) { }
+	public ExpectLeftBraceException(string found, Range range) : base($"Expected left brace, but found `{found}` instead", range) { }
 }
 
 public class ExpectRightBraceException : ParserException
 {
-	public ExpectRightBraceException(string found, int line) : base($"Expected right brace, but found `{found}`", line) { }
+	public ExpectRightBraceException(string found, Range range) : base($"Expected right brace, but found `{found}`", range) { }
 }
 
 public class ExpectInKeywordException : ParserException
 {
-	public ExpectInKeywordException(string found, int line) : base($"Expected `in` keyword, but found `{found}` instead", line) { }
+	public ExpectInKeywordException(string found, Range range) : base($"Expected `in` keyword, but found `{found}` instead", range) { }
 }
 
 public class CanOnlyDeferFunctionCallException : ParserException
 {
-	public CanOnlyDeferFunctionCallException(int line) : base("Can only defer function call", line) { }
+	public CanOnlyDeferFunctionCallException(Range range) : base("Can only defer function call", range) { }
 }
 
 public class ExpectColonException : ParserException
 {
-	public ExpectColonException(string found, int line) : base($"Expected `:`, but found `{found}` instead", line) { }
+	public ExpectColonException(string found, Range range) : base($"Expected `:`, but found `{found}` instead", range) { }
 }
 
 public class ExpectColonEqualException : ParserException
 {
-	public ExpectColonEqualException(string found, int line) : base($"Expected `:=`, but found `{found}` instead", line) { }
+	public ExpectColonEqualException(string found, Range range) : base($"Expected `:=`, but found `{found}` instead", range) { }
 }
 
 public class InvalidAssignmentTargetException : ParserException
 {
-	public InvalidAssignmentTargetException(int line) : base("Invalid assignment target", line) { }
+	public InvalidAssignmentTargetException(Range range) : base("Invalid assignment target", range) { }
 }
 
 public class UnreachableCodeException : ParserException
 {
-	public UnreachableCodeException(int line) : base("Unreachable code", line) { }
+	public UnreachableCodeException(Range range) : base("Unreachable code", range) { }
 }
 
 public class ExpectPropertyNameException : ParserException
 {
-	public ExpectPropertyNameException(string found, int line) : base($"Expected property name, but found `{found}` instead", line) { }
+	public ExpectPropertyNameException(string found, Range range) : base($"Expected property name, but found `{found}` instead", range) { }
 }
 
 public class ExpectIntLiteralException : ParserException
 {
-	public ExpectIntLiteralException(string found, int line) : base($"Expected int literal, but found `{found}` instead", line) { }
+	public ExpectIntLiteralException(string found, Range range) : base($"Expected int literal, but found `{found}` instead", range) { }
 }
 
 public class ExpectRightBracketException : ParserException
 {
-	public ExpectRightBracketException(string found, int line) : base($"Expected `]`, but found `{found}` instead", line) { }
+	public ExpectRightBracketException(string found, Range range) : base($"Expected `]`, but found `{found}` instead", range) { }
 }
 
 public class ExpectCommaException : ParserException
 {
-	public ExpectCommaException(string found, int line) : base($"Expected `,`, but found `{found}` instead", line) { }
+	public ExpectCommaException(string found, Range range) : base($"Expected `,`, but found `{found}` instead", range) { }
 }
 
 public class ExpectExpressionException : ParserException
 {
-	public ExpectExpressionException(int line) : base("Expected expression", line) { }
+	public ExpectExpressionException(Range range) : base("Expected expression", range) { }
 }
 
 public class ParameterDefaultValueMustBeALiteralException : ParserException
 {
-	public ParameterDefaultValueMustBeALiteralException(int line) : base("Parameter default value must be a literal", line) { }
+	public ParameterDefaultValueMustBeALiteralException(Range range) : base("Parameter default value must be a literal", range) { }
 }
 
 public class InvalidIndexTypeException : ParserException
 {
-	public InvalidIndexTypeException(int line) : base("Invalid index type", line) { }
+	public InvalidIndexTypeException(Range range) : base("Invalid index type", range) { }
 }
 
 public class PostfixIndexCannotBeEmptyException : ParserException
 {
-	public PostfixIndexCannotBeEmptyException(int line) : base("Postfix index cannot be empty", line) { }
+	public PostfixIndexCannotBeEmptyException(Range range) : base("Postfix index cannot be empty", range) { }
 }
 
 public class ExpectFunctionSignatureException : ParserException
 {
-	public ExpectFunctionSignatureException(int line) : base("Expected function signature", line) { }
+	public ExpectFunctionSignatureException(Range range) : base("Expected function signature", range) { }
 }
 
 public class ExpectNewLineException : ParserException
 {
-	public ExpectNewLineException(string found, int line) : base($"Expected '\n', but found '{found}'", line) { }
+	public ExpectNewLineException(string found, Range range) : base($"Expected '\n', but found '{found}'", range) { }
 }
 
 public class FileMustBeginWithModStmtException : ParserException
 {
-	public FileMustBeginWithModStmtException(int line) : base("Cannot omit `mod` statement", line) { }
+	public FileMustBeginWithModStmtException(Range range) : base("Cannot omit `mod` statement", range) { }
 }
 
 public class CanOnlyCheckFunctionCallException : ParserException
 {
-	public CanOnlyCheckFunctionCallException(int line) : base("Can only check function call", line) { }
+	public CanOnlyCheckFunctionCallException(Range range) : base("Can only check function call", range) { }
 }

--- a/AuraLang/Exceptions/Scanner/Scanner.cs
+++ b/AuraLang/Exceptions/Scanner/Scanner.cs
@@ -1,8 +1,10 @@
-﻿namespace AuraLang.Exceptions.Scanner;
+﻿using Range = AuraLang.Location.Range;
+
+namespace AuraLang.Exceptions.Scanner;
 
 public abstract class ScannerException : AuraException
 {
-	protected ScannerException(string message, int line) : base(message, line) { }
+	protected ScannerException(string message, Range range) : base(message, range) { }
 }
 
 /// <summary>
@@ -10,7 +12,7 @@ public abstract class ScannerException : AuraException
 /// </summary>
 public class UnterminatedStringException : ScannerException
 {
-	public UnterminatedStringException(int line) : base("Unterminated string", line) { }
+	public UnterminatedStringException(Range range) : base("Unterminated string", range) { }
 }
 
 /// <summary>
@@ -18,7 +20,7 @@ public class UnterminatedStringException : ScannerException
 /// </summary>
 public class UnterminatedCharException : ScannerException
 {
-	public UnterminatedCharException(int line) : base("Unterminated char", line) { }
+	public UnterminatedCharException(Range range) : base("Unterminated char", range) { }
 }
 
 /// <summary>
@@ -26,7 +28,7 @@ public class UnterminatedCharException : ScannerException
 /// </summary>
 public class CharLengthGreaterThanOneException : ScannerException
 {
-	public CharLengthGreaterThanOneException(int line) : base("Char length greater than 1", line) { }
+	public CharLengthGreaterThanOneException(Range range) : base("Char length greater than 1", range) { }
 }
 
 /// <summary>
@@ -34,7 +36,7 @@ public class CharLengthGreaterThanOneException : ScannerException
 /// </summary>
 public class EmptyCharException : ScannerException
 {
-	public EmptyCharException(int line) : base("Empty char", line) { }
+	public EmptyCharException(Range range) : base("Empty char", range) { }
 }
 
 /// <summary>
@@ -42,5 +44,5 @@ public class EmptyCharException : ScannerException
 /// </summary>
 public class InvalidCharacterException : ScannerException
 {
-	public InvalidCharacterException(char found, int line) : base($"Invalid character: `{found}`", line) { }
+	public InvalidCharacterException(char found, Range range) : base($"Invalid character: `{found}`", range) { }
 }

--- a/AuraLang/Exceptions/TypeChecker/TypeChecker.cs
+++ b/AuraLang/Exceptions/TypeChecker/TypeChecker.cs
@@ -1,150 +1,151 @@
 ﻿using AuraLang.Types;
+using Range = AuraLang.Location.Range;
 
 namespace AuraLang.Exceptions.TypeChecker;
 
 public abstract class TypeCheckerException : AuraException
 {
-	protected TypeCheckerException(string message, int line) : base(message, line) { }
+	protected TypeCheckerException(string message, Range range) : base(message, range) { }
 }
 
 public class UnknownStatementTypeException : TypeCheckerException
 {
-	public UnknownStatementTypeException(int line) : base("Unknown statement type", line) { }
+	public UnknownStatementTypeException(Range range) : base("Unknown statement type", range) { }
 }
 
 public class UnknownExpressionTypeException : TypeCheckerException
 {
-	public UnknownExpressionTypeException(int line) : base("Unknown expression type", line)
+	public UnknownExpressionTypeException(Range range) : base("Unknown expression type", range)
 	{
 	}
 }
 
 public class UnexpectedTypeException : TypeCheckerException
 {
-	public UnexpectedTypeException(int line) : base("Unexpected type", line) { }
+	public UnexpectedTypeException(Range range) : base("Unexpected type", range) { }
 }
 
 public class ExpectIterableException : TypeCheckerException
 {
-	public ExpectIterableException(int line) : base("Expect iterable", line) { }
+	public ExpectIterableException(Range range) : base("Expect iterable", range) { }
 }
 
 public class TypeMismatchException : TypeCheckerException
 {
-	public TypeMismatchException(int line) : base("Type mismatch", line) { }
+	public TypeMismatchException(Range range) : base("Type mismatch", range) { }
 }
 
 public class MismatchedUnaryOperatorAndOperandException : TypeCheckerException
 {
-	public MismatchedUnaryOperatorAndOperandException(string unaryOperator, AuraType operandType, int line)
-		: base($"Mismatched unary operator and operand. Operator `{unaryOperator}` not valid with type {operandType}.", line) { }
+	public MismatchedUnaryOperatorAndOperandException(string unaryOperator, AuraType operandType, Range range)
+		: base($"Mismatched unary operator and operand. Operator `{unaryOperator}` not valid with type {operandType}.", range) { }
 }
 
 public class ExpectIndexableException : TypeCheckerException
 {
-	public ExpectIndexableException(int line) : base("Expect indexable", line) { }
+	public ExpectIndexableException(Range range) : base("Expect indexable", range) { }
 }
 
 public class ExpectRangeIndexableException : TypeCheckerException
 {
-	public ExpectRangeIndexableException(int line) : base("Expect range indexable", line) { }
+	public ExpectRangeIndexableException(Range range) : base("Expect range indexable", range) { }
 }
 
 public class IncorrectNumberOfArgumentsException : TypeCheckerException
 {
-	public IncorrectNumberOfArgumentsException(int have, int want, int line)
-		: base($"Incorrect number of arguments. Have {have}, but want {want}.", line) { }
+	public IncorrectNumberOfArgumentsException(int have, int want, Range range)
+		: base($"Incorrect number of arguments. Have {have}, but want {want}.", range) { }
 }
 
 public class CannotGetFromNonClassException : TypeCheckerException
 {
-	public CannotGetFromNonClassException(string varName, AuraType varType, string attributeName, int line)
-		: base($"Cannot get attribute from non-class. Trying to get attribute `{attributeName}` from `{varName}`, which has type `{varType}`.", line) { }
+	public CannotGetFromNonClassException(string varName, AuraType varType, string attributeName, Range range)
+		: base($"Cannot get attribute from non-class. Trying to get attribute `{attributeName}` from `{varName}`, which has type `{varType}`.", range) { }
 }
 
 public class ClassAttributeDoesNotExistException : TypeCheckerException
 {
-	public ClassAttributeDoesNotExistException(string className, string attributeName, int line)
-		: base($"Attribute `{attributeName}` does not exist on class `{className}`.", line) { }
+	public ClassAttributeDoesNotExistException(string className, string attributeName, Range range)
+		: base($"Attribute `{attributeName}` does not exist on class `{className}`.", range) { }
 }
 
 public class InvalidUseOfYieldKeywordException : TypeCheckerException
 {
-	public InvalidUseOfYieldKeywordException(int line) : base("Invalid use of yield keyword", line) { }
+	public InvalidUseOfYieldKeywordException(Range range) : base("Invalid use of yield keyword", range) { }
 }
 
 public class InvalidUseOfBreakKeywordException : TypeCheckerException
 {
-	public InvalidUseOfBreakKeywordException(int line) : base("Invalid use of break keyword", line) { }
+	public InvalidUseOfBreakKeywordException(Range range) : base("Invalid use of break keyword", range) { }
 }
 
 public class InvalidUseOfContinueKeywordException : TypeCheckerException
 {
-	public InvalidUseOfContinueKeywordException(int line) : base("Invalid use of continue keyword", line) { }
+	public InvalidUseOfContinueKeywordException(Range range) : base("Invalid use of continue keyword", range) { }
 }
 
 public class CannotMixNamedAndUnnamedArgumentsException : TypeCheckerException
 {
-	public CannotMixNamedAndUnnamedArgumentsException(string functionName, int line)
-		: base($"Cannot mix named and unnamed arguments for function `{functionName}`.", line) { }
+	public CannotMixNamedAndUnnamedArgumentsException(string functionName, Range range)
+		: base($"Cannot mix named and unnamed arguments for function `{functionName}`.", range) { }
 }
 
 public class MustSpecifyValueForArgumentWithoutDefaultValueException : TypeCheckerException
 {
-	public MustSpecifyValueForArgumentWithoutDefaultValueException(string functionName, string argument, int line)
-		: base($"Argument `{argument}` in call to `{functionName}` does not have a default value specified, so a value must be specified.", line) { }
+	public MustSpecifyValueForArgumentWithoutDefaultValueException(string functionName, string argument, Range range)
+		: base($"Argument `{argument}` in call to `{functionName}` does not have a default value specified, so a value must be specified.", range) { }
 }
 
 public class MustSpecifyInitialValueForNonDefaultableTypeException : TypeCheckerException
 {
-	public MustSpecifyInitialValueForNonDefaultableTypeException(AuraType typ, int line)
-		: base($"The type `{typ}` does not have a default value specified, so an initial value must be provided.", line) { }
+	public MustSpecifyInitialValueForNonDefaultableTypeException(AuraType typ, Range range)
+		: base($"The type `{typ}` does not have a default value specified, so an initial value must be provided.", range) { }
 }
 
 public class UnknownVariableException : TypeCheckerException
 {
-	public UnknownVariableException(string varName, int line)
-		: base($"Unknown variable `{varName}`.", line) { }
+	public UnknownVariableException(string varName, Range range)
+		: base($"Unknown variable `{varName}`.", range) { }
 }
 
 public class CannotImplementNonInterfaceException : TypeCheckerException
 {
-	public CannotImplementNonInterfaceException(string name, int line)
-		: base($"`{name}` is not an interface, so it cannot be implemented.", line) { }
+	public CannotImplementNonInterfaceException(string name, Range range)
+		: base($"`{name}` is not an interface, so it cannot be implemented.", range) { }
 }
 
 public class MissingInterfaceMethodException : TypeCheckerException
 {
-	public MissingInterfaceMethodException(string interfaceName, string missingMethod, int line)
-		: base($"All implementors of `{interfaceName}` must implement the method `{missingMethod}`.", line) { }
+	public MissingInterfaceMethodException(string interfaceName, string missingMethod, Range range)
+		: base($"All implementors of `{interfaceName}` must implement the method `{missingMethod}`.", range) { }
 }
 
 public class CannotSetOnNonClassException : TypeCheckerException
 {
-	public CannotSetOnNonClassException(int line) : base("Cannot set on non-class", line) { }
+	public CannotSetOnNonClassException(Range range) : base("Cannot set on non-class", range) { }
 }
 
 public class CannotIncrementNonNumberException : TypeCheckerException
 {
-	public CannotIncrementNonNumberException(int line) : base("Cannot increment non-number", line) { }
+	public CannotIncrementNonNumberException(Range range) : base("Cannot increment non-number", range) { }
 }
 
 public class CannotDecrementNonNumberException : TypeCheckerException
 {
-	public CannotDecrementNonNumberException(int line) : base("Cannot decrement non-number", line) { }
+	public CannotDecrementNonNumberException(Range range) : base("Cannot decrement non-number", range) { }
 }
 
 public class DirectoryCannotContainMultipleModulesException : TypeCheckerException
 {
-	public DirectoryCannotContainMultipleModulesException(int line) : base("Directory cannot contain multiple modules", line) { }
+	public DirectoryCannotContainMultipleModulesException(Range range) : base("Directory cannot contain multiple modules", range) { }
 }
 
 public class InvalidUseOfCheckKeywordException : TypeCheckerException
 {
-	public InvalidUseOfCheckKeywordException(int line) : base("Invalid use of `check` keyword", line) { }
+	public InvalidUseOfCheckKeywordException(Range range) : base("Invalid use of `check` keyword", range) { }
 }
 
 public class CannotMixTypeAnnotationsException : TypeCheckerException
 {
-	public CannotMixTypeAnnotationsException(int line) : base("Cannot mix type annotations", line) { }
+	public CannotMixTypeAnnotationsException(Range range) : base("Cannot mix type annotations", range) { }
 }

--- a/AuraLang/ModuleCompiler/ModuleCompiler.cs
+++ b/AuraLang/ModuleCompiler/ModuleCompiler.cs
@@ -4,6 +4,7 @@ using AuraLang.Exceptions.TypeChecker;
 using AuraLang.FileCompiler;
 using AuraLang.ImportedFileProvider;
 using AuraLang.TypeChecker;
+using Range = AuraLang.Location.Range;
 
 namespace AuraLang.ModuleCompiler;
 
@@ -55,7 +56,8 @@ public class AuraModuleCompiler
 		var modNames = untypedAsts.Select(pair => pair.parsedOutput.Find(node => node is UntypedMod));
 		if (!modNames.All(name => ((UntypedMod)name!).Value.Value == ((UntypedMod)modNames.First()!).Value.Value))
 		{
-			throw new DirectoryCannotContainMultipleModulesException(1);
+			// TODO get the name of the file whose module name doesn't match
+			throw new DirectoryCannotContainMultipleModulesException(new Range());
 		}
 
 		// Build symbols table
@@ -77,7 +79,8 @@ public class AuraModuleCompiler
 		var modNames = untypedAsts.Select(pair => pair.parsedOutput.Find(node => node is UntypedMod));
 		if (!modNames.All(name => ((UntypedMod)name!).Value.Value == ((UntypedMod)modNames.First()!).Value.Value))
 		{
-			throw new DirectoryCannotContainMultipleModulesException(1);
+			// TODO get the name of the file whose module name doesn't match
+			throw new DirectoryCannotContainMultipleModulesException(new Range());
 		}
 
 		// Build symbols table

--- a/AuraLang/Scanner/Scanner.cs
+++ b/AuraLang/Scanner/Scanner.cs
@@ -223,7 +223,15 @@ public class AuraScanner
 			default:
 				// If the character isn't an alphabetical or numeric character, and it isn't a valid symbol,
 				// then it must be an invalid character
-				throw new InvalidCharacterException(c, _line);
+				throw new InvalidCharacterException(
+					found: c,
+					range: new Range(
+						start: new Position(
+							character: _startCharPos,
+							line: _line),
+						end: new Position(
+							character: _currentCharPos,
+							line: _line)));
 		}
 	}
 
@@ -560,7 +568,13 @@ public class AuraScanner
 		// Scan the entire token, up until the closing double quote
 		while (!IsAtEnd() && Peek() != '"') s += Advance();
 		// If we've reached the end of the file without encountering the closing ", we throw an exception
-		if (IsAtEnd()) throw new UnterminatedStringException(_line);
+		if (IsAtEnd()) throw new UnterminatedStringException(new Range(
+			start: new Position(
+				character: _startCharPos,
+				line: _line),
+			end: new Position(
+				character: _currentCharPos,
+				line: _line)));
 
 		var range = new Range(
 			start: new Position(
@@ -590,12 +604,30 @@ public class AuraScanner
 		// Scan the entire token, up until the closing single quote
 		while (!IsAtEnd() && Peek() != '\'') s += Advance();
 		// If we've reached the end of the file without encountering the closing ', we throw an exception
-		if (IsAtEnd()) throw new UnterminatedCharException(_line);
+		if (IsAtEnd()) throw new UnterminatedCharException(new Range(
+			start: new Position(
+				character: _startCharPos,
+				line: _line),
+			end: new Position(
+				character: _currentCharPos,
+				line: _line)));
 		// Advance past the closing '
 		Advance();
 		// Ensure that the char is a single character
-		if (s.Length == 0) throw new EmptyCharException(_line);
-		if (s.Length > 1) throw new CharLengthGreaterThanOneException(_line);
+		if (s.Length == 0) throw new EmptyCharException(new Range(
+			start: new Position(
+				character: _startCharPos,
+				line: _line),
+			end: new Position(
+				character: _currentCharPos,
+				line: _line)));
+		if (s.Length > 1) throw new CharLengthGreaterThanOneException(new Range(
+			start: new Position(
+				character: _startCharPos,
+				line: _line),
+			end: new Position(
+				character: _currentCharPos,
+				line: _line)));
 
 		var range = new Range(
 			start: new Position(


### PR DESCRIPTION
* The `line` parameter in all Aura exceptions has been replaced by a `Range` value
* The line can still be extracted from the range