### PR TITLE
Fix hoverable range

### DIFF
--- a/AuraLang.Lsp/LanguageServer/LanguageServer.cs
+++ b/AuraLang.Lsp/LanguageServer/LanguageServer.cs
@@ -197,13 +197,13 @@ public class AuraLanguageServer : IDisposable
 			{
 				Start = new Position
 				{
-					Character = node.Range.Start.Character,
-					Line = node.Range.Start.Line
+					Character = node.HoverableRange.Start.Character,
+					Line = node.HoverableRange.Start.Line
 				},
 				End = new Position
 				{
-					Character = node.Range.End.Character,
-					Line = node.Range.End.Line
+					Character = node.HoverableRange.End.Character,
+					Line = node.HoverableRange.End.Line
 				}
 			}
 		};


### PR DESCRIPTION
The returned `Hover` object was previously including the AST node's range, but for some nodes their hoverable range is different than their entire range. The returned `Hover` object has been updated to use the node's hoverable range.