### PR TITLE
Catch exception during build process

### DIFF
--- a/AuraLang.Cli/Commands/Build.cs
+++ b/AuraLang.Cli/Commands/Build.cs
@@ -53,11 +53,21 @@ public class Build : AuraCommand
 		// Build Go binary executable
 		Directory.SetCurrentDirectory("./build/pkg");
 		FormatGoProject();
-		var build = new Process { StartInfo = new ProcessStartInfo { FileName = "go", Arguments = "build" } };
+		var build = new Process
+		{
+			StartInfo = new ProcessStartInfo
+			{
+				FileName = "go",
+				Arguments = "build",
+				RedirectStandardError = true,
+				RedirectStandardOutput = true
+			}
+		};
 		build.Start();
 		await build.WaitForExitAsync();
 
-		return 0;
+		if (build.ExitCode > 0) Console.Write(await build.StandardError.ReadToEndAsync());
+		return build.ExitCode;
 	}
 
 	private void WriteGoOutputFile(string auraPath, string content)

--- a/AuraLang.Cli/Commands/Run.cs
+++ b/AuraLang.Cli/Commands/Run.cs
@@ -28,7 +28,8 @@ public class Run : AuraCommand
 	/// <returns>An integer status indicating if the process succeeded</returns>
 	protected override async Task<int> ExecuteCommandAsync()
 	{
-		await Build.ExecuteAsync();
+		var exitCode = await Build.ExecuteAsync();
+		if (exitCode > 0) return exitCode;
 		// After build is finished executing, the current directory will be the `build/pkg` directory, so we return to the project's root directory here
 		Directory.SetCurrentDirectory("../..");
 		var projName = _toml.GetProjectName();


### PR DESCRIPTION
* When the build process throws an exception, that exception shouldn't be visible to the end user
* Previously, if the final executable wasn't correctly built, the `aura run` command would still try to run that executable, which didn't exist. Thus, an error was raised and shown as output to the user
* However, at least for now, I don't want to completely suppress the Go compiler's error output because the Aura compiler doesn't support all of the Go compiler's error checking. For example, the Aura compiler doesn't mind if a variable is declared but not used, whereas the Go compiler throws in an error in that case. For this reason, the Go error output can still be valuable to the end user.
* Therefore, the approach is to check the exit code of the process that creates the final executable. If it fails, we print the Go compiler's error output and return early to avoid trying to execute that non-existent file